### PR TITLE
Update SETUP.sql

### DIFF
--- a/src/SETUP.sql
+++ b/src/SETUP.sql
@@ -108,8 +108,7 @@ CREATE TABLE pgmemento.transaction_log
   txid BIGINT NOT NULL,
   stmt_date TIMESTAMP WITH TIME ZONE NOT NULL,
   user_name TEXT,
-  client_name TEXT,
-  application_name TEXT
+  client_name TEXT
 );
 
 ALTER TABLE pgmemento.transaction_log
@@ -399,25 +398,6 @@ CREATE OR REPLACE VIEW pgmemento.audit_tables_dependency AS
     schemaname,
     depth,
     tablename;
- 
-CREATE OR REPLACE VIEW pgmemento.audit_full AS
- SELECT t1.audit_id,
-    t1.changes,
-    t2.transaction_id,
-    t2.table_operation,
-    t2.table_relid,
-    t3.schema_name,
-    t3.table_name,
-    t4.stmt_date,
-    t4.user_name,
-    t4.client_name,
-    t4.application_name
-   FROM pgmemento.row_log t1
-     LEFT JOIN pgmemento.table_event_log t2 ON t2.id = t1.event_id
-     LEFT JOIN pgmemento.audit_table_log t3 ON t3.relid = t2.table_relid
-     LEFT JOIN pgmemento.transaction_log t4 ON t2.transaction_id = t4.txid
-  ORDER BY t4.stmt_date DESC;
-
 
 /**********************************************************
 * UN/REGISTER TABLE
@@ -791,9 +771,9 @@ DECLARE
 BEGIN
   -- try to log corresponding transaction
   INSERT INTO pgmemento.transaction_log 
-    (txid, stmt_date, user_name, client_name, application_name)
+    (txid, stmt_date, user_name, client_name)
   VALUES 
-    (txid_current(), statement_timestamp(), current_user, inet_client_addr(), current_setting('application_name'))
+    (txid_current(), statement_timestamp(), current_user, inet_client_addr())
   ON CONFLICT (txid)
     DO NOTHING;
 


### PR DESCRIPTION
Added the new column `application_name` to `transaction_log` table.
During connection, it's possible to specify `application_name` parameter, it can bu useful to store information about application user that generally is different from connection username.

Added view `audit_full`, it's useful to get a list of changes.

Updated trigger function `log_update()`: now trigger update works correctly with json data type.
When you update a json/jsonb column and add a new node in json, pgMemento didn't report the change.
The only changes reported were: edit an existing json node or delete an existing json node.
Now when you add a new node inside a json, you'll find the old value in `row_logs`.