### PR TITLE
fixed: alter table with column with numeric type with scale defined

### DIFF
--- a/src/DDL_LOG.sql
+++ b/src/DDL_LOG.sql
@@ -547,6 +547,7 @@ BEGIN
     -- remove schema and table name from DDL string and try to process columns
     ddl_text := replace(ddl_text, schemaname || '.', '');
     ddl_text := replace(ddl_text, tablename, '');
+    ddl_text := regexp_replace(ddl_text, 'numeric\((\d+),\ (\d+)\)', 'numeric(\1,\2)');
     objs := regexp_split_to_array(ddl_text, E'\\s+');
 
     FOREACH columnname IN ARRAY objs LOOP


### PR DESCRIPTION
## Expected Behavior
I'd like to be able to alter table and add column with numeric type with scale defined and not experience an error ;)

## Current Behavior

```
db=# alter table test_table add column new_test_column numeric(21, 2);
ERROR:  syntax error at end of input
CONTEXT:  invalid type name "numeric(21"
PL/pgSQL function table_alter_pre_trigger() line 148 at IF
```
## Workaround
The issue only exists, where there is a space between precision part and scale part of a numeric type. When you remove it, everything works fine:

```
db=# alter table test_table add column new_test_column numeric(21,2);
ALTER TABLE
```

## Possible Solution
See code. 

## Steps to Reproduce
```
db=# create table test_table (num1 numeric(21, 1));
CREATE TABLE
db=# alter table test_table add column num2 numeric(21, 2);
ERROR:  syntax error at end of input
CONTEXT:  invalid type name "numeric(21"
PL/pgSQL function table_alter_pre_trigger() line 148 at IF
```
Notice that there is no problem with the space in create table query.

## Detailed Description
The bug is in `table_alter_pre_trigger` function. I debugged it and it seems that `regexp_split_to_array` wrongly split the part of query which at the time left to interpret.

```
db=# select regexp_split_to_array('add column num2 numeric(21, 2)', E'\\s+');
       regexp_split_to_array
------------------------------------
 {add,column,num2,"numeric(21,",2)}
(1 row)
```
It was split into 5 parts instead of 4.
When you remove the space and try again, you will get:
```
db=# select regexp_split_to_array('add column num2 numeric(21,2)', E'\\s+');
       regexp_split_to_array
-----------------------------------
 {add,column,num2,"numeric(21,2)"}
(1 row)
```