### PR TITLE
add option to also log new data in row_log

### DIFF
--- a/INIT.sql
+++ b/INIT.sql
@@ -14,6 +14,7 @@
 -- ChangeLog:
 --
 -- Version | Date       | Description                                  | Author
+-- 0.2.0     2020-02-29   add new option to log new data in row_log      FKun
 -- 0.1.0     2016-03-09   initial commit                                 FKun
 --
 
@@ -24,16 +25,22 @@ SET client_min_messages TO WARNING;
 \echo
 \prompt 'Please enter the name of the schema to be used along with pgMemento: ' schema_name
 \prompt 'Specify tables to be excluded from logging processes (seperated by comma): ' except_tables
-\prompt 'Log existing data as inserted (baseline)? (y|n): ' log_data
-\prompt 'Trigger CREATE TABLE statements? (y|n): ' trigger_create_table
+\prompt 'Store new data in audit logs, too? (y|N): ' log_new_data
+\prompt 'Log existing data as inserted (baseline)? (y|N): ' log_baseline
+\prompt 'Trigger CREATE TABLE statements? (y|N): ' trigger_create_table
 
 \echo
 \echo 'Create event trigger to log schema changes ...'
-SELECT pgmemento.create_schema_event_trigger(CASE WHEN lower(:'trigger_create_table') = 'y' OR lower(:'trigger_create_table') = 'yes' THEN TRUE ELSE FALSE END);
+SELECT pgmemento.create_schema_event_trigger(
+  CASE WHEN lower(:'trigger_create_table') = 'y' OR lower(:'trigger_create_table') = 'yes' THEN TRUE ELSE FALSE END,
+  CASE WHEN lower(:'log_new_data') = 'y' OR lower(:'log_new_data') = 'yes' THEN TRUE ELSE FALSE END);
 
 \echo
 \echo 'Start auditing for tables in ':schema_name' schema ...'
-SELECT pgmemento.create_schema_audit(:'schema_name', CASE WHEN lower(:'log_data') = 'y' OR lower(:'log_data') = 'yes' THEN TRUE ELSE FALSE END, string_to_array(:'except_tables',','));
+SELECT pgmemento.create_schema_audit(:'schema_name',
+  CASE WHEN lower(:'log_baseline') = 'y' OR lower(:'log_baseline') = 'yes' THEN TRUE ELSE FALSE END,
+  CASE WHEN lower(:'log_new_data') = 'y' OR lower(:'log_new_data') = 'yes' THEN TRUE ELSE FALSE END,
+  string_to_array(:'except_tables',','));
 
 \echo
 \echo 'pgMemento is now initialized on ':schema_name' schema.'

--- a/START_AUDITING.sql
+++ b/START_AUDITING.sql
@@ -14,6 +14,7 @@
 -- ChangeLog:
 --
 -- Version | Date       | Description                                  | Author
+-- 0.2.0     2020-02-29   add new option to log new data in row_log      FKun
 -- 0.1.0     2016-03-09   initial commit                                 FKun
 --
 
@@ -24,5 +25,6 @@ SET client_min_messages TO WARNING;
 \echo
 \prompt 'Please enter the name of the schema to be used along with pgMemento: ' schema_name
 \prompt 'Specify tables to be excluded from logging processes (seperated by comma): ' except_tables
+\prompt 'Store new data in audit logs, too? (y|N): ' log_new_data
 
 \i ctl/START.sql

--- a/UPGRADE_v061_to_v07.sql
+++ b/UPGRADE_v061_to_v07.sql
@@ -56,6 +56,20 @@ DROP FUNCTION IF EXISTS pgememento.log_table_state(e_id INTEGER, columns TEXT[],
 
 DROP FUNCTION IF EXISTS pgmemento.restore_record_definition(start_from_tid INTEGER, end_at_tid INTEGER, table_oid OID);
 
+DROP FUNCTION IF EXISTS pgmemento.log_schema_baseline(schema_name TEXT);
+
+DROP FUNCTION IF EXISTS pgmemento.log_table_baseline(table_name TEXT, schema_name TEXT);
+
+DROP FUNCTION IF EXISTS pgmemento.create_schema_log_trigger(schema_name TEXT, except_tables);
+
+DROP FUNCTION IF EXISTS pgmemento.create_table_log_trigger(table_name TEXT, schema_name TEXT);
+
+DROP FUNCTION IF EXISTS pgmemento.create_schema_audit(schema_name TEXT, log_state BOOLEAN, except_tables TEXT[]);
+
+DROP FUNCTION IF EXISTS pgmemento.create_table_audit(table_name TEXT, schema_name TEXT, log_state BOOLEAN);
+
+DROP FUNCTION IF EXISTS pgmemento.create_schema_event_trigger(trigger_create_table BOOLEAN);
+
 DROP AGGREGATE IF EXISTS pgmemento.jsonb_merge(jsonb);
 
 \echo

--- a/ctl/START.sql
+++ b/ctl/START.sql
@@ -14,12 +14,17 @@
 -- ChangeLog:
 --
 -- Version | Date       | Description                                  | Author
+-- 0.2.0     2020-02-29   add new option to log new data in row_log      FKun
 -- 0.1.0     2016-03-09   initial commit                                 FKun
 --
 
 \echo
 \echo 'Creating triggers for tables in ':schema_name' schema ...'
-SELECT pgmemento.create_schema_log_trigger(:'schema_name', string_to_array(:'except_tables',','));
+SELECT pgmemento.create_schema_log_trigger(
+  :'schema_name',
+  CASE WHEN lower(:'log_new_data') = 'y' OR lower(:'log_new_data') = 'yes' THEN TRUE ELSE FALSE END,
+  string_to_array(:'except_tables',',')
+);
 
 \echo
 \echo 'pgMemento is now started on ':schema_name' schema.'

--- a/src/DDL_LOG.sql
+++ b/src/DDL_LOG.sql
@@ -946,7 +946,7 @@ BEGIN
                   altered_columns := array_append(altered_columns, columnname);
 
                   -- check if logging column content is really required
-                  column_type := pgmemento.fetch_ident(ddl_text, 5);
+                  column_type := pgmemento.fetch_ident(ddl_text, 6);
                   IF lower(column_type) LIKE '% collate %' OR lower(column_type) LIKE '% using %' THEN
                     altered_columns_log := array_append(altered_columns_log, columnname);
                   END IF;

--- a/src/LOG_UTIL.sql
+++ b/src/LOG_UTIL.sql
@@ -16,6 +16,7 @@
 -- ChangeLog:
 --
 -- Version | Date       | Description                                  | Author
+-- 0.7.3     2020-02-29   reflect new schema of row_log table            FKun
 -- 0.7.2     2020-02-09   reflect changes on schema and triggers         FKun
 -- 0.7.1     2020-02-08   stop using trim_outer_quotes                   FKun
 -- 0.7.0     2019-03-23   reflect schema changes in UDFs                 FKun
@@ -285,10 +286,10 @@ $$
 UPDATE
   pgmemento.row_log
 SET
-  changes = changes - $2
+  old_data = old_data - $2
 WHERE
   audit_id = $1
-  AND changes @> jsonb_build_object($2, $3)
+  AND old_data @> jsonb_build_object($2, $3)
 RETURNING
   id;
 $$
@@ -304,10 +305,10 @@ $$
 UPDATE
   pgmemento.row_log
 SET
-  changes = jsonb_set(changes, $2, to_jsonb($4), FALSE)
+  old_data = jsonb_set(old_data, $2, to_jsonb($4), FALSE)
 WHERE
   audit_id = $1
-  AND changes @> jsonb_build_object($2[1], $3)
+  AND old_data @> jsonb_build_object($2[1], $3)
 RETURNING
   id;
 $$

--- a/src/SETUP.sql
+++ b/src/SETUP.sql
@@ -15,6 +15,7 @@
 -- ChangeLog:
 --
 -- Version | Date       | Description                                       | Author
+-- 0.7.4     2020-02-29   added option to also log new data in row_log        FKun
 -- 0.7.3     2020-02-09   reflect changes on schema and triggers              FKun
 -- 0.7.2     2020-02-08   new get_table_oid function to replace trimming      FKun
 -- 0.7.1     2019-04-21   introduce new event RECREATE TABLE with op_id       FKun
@@ -62,12 +63,13 @@
 * FUNCTIONS:
 *   column_array_to_column_list(columns TEXT[]) RETURNS TEXT
 *   create_schema_audit(schema_name TEXT DEFAULT 'public'::text, log_state BOOLEAN DEFAULT TRUE,
-*     except_tables TEXT[] DEFAULT '{}') RETURNS SETOF VOID
+*     include_new BOOLEAN DEFAULT FALSE, except_tables TEXT[] DEFAULT '{}') RETURNS SETOF VOID
 *   create_schema_audit_id(schema_name TEXT DEFAULT 'public'::text, except_tables TEXT[] DEFAULT '{}') RETURNS SETOF VOID
-*   create_schema_log_trigger(schema_name TEXT DEFAULT 'public'::text, except_tables TEXT[] DEFAULT '{}') RETURNS SETOF VOID
-*   create_table_audit(table_name TEXT, schema_name TEXT DEFAULT 'public'::text, log_state BOOLEAN DEFAULT TRUE) RETURNS SETOF VOID
+*   create_schema_log_trigger(schema_name TEXT DEFAULT 'public'::text, include_new BOOLEAN DEFAULT FALSE, except_tables TEXT[] DEFAULT '{}') RETURNS SETOF VOID
+*   create_table_audit(table_name TEXT, schema_name TEXT DEFAULT 'public'::text,
+*     log_state BOOLEAN DEFAULT TRUE, include_new BOOLEAN DEFAULT FALSE) RETURNS SETOF VOID
 *   create_table_audit_id(table_name TEXT, schema_name TEXT DEFAULT 'public'::text) RETURNS SETOF VOID
-*   create_table_log_trigger(table_name TEXT, schema_name TEXT DEFAULT 'public'::text) RETURNS SETOF VOID
+*   create_table_log_trigger(table_name TEXT, schema_name TEXT DEFAULT 'public'::text, include_new BOOLEAN DEFAULT FALSE) RETURNS SETOF VOID
 *   drop_schema_audit(schema_name TEXT DEFAULT 'public'::text, except_tables TEXT[] DEFAULT '{}') RETURNS SETOF VOID
 *   drop_schema_audit_id(schema_name TEXT DEFAULT 'public'::text, except_tables TEXT[] DEFAULT '{}') RETURNS SETOF VOID
 *   drop_schema_log_trigger(schema_name TEXT DEFAULT 'public'::text, except_tables TEXT[] DEFAULT '{}') RETURNS SETOF VOID
@@ -77,10 +79,11 @@
 *   get_operation_id(operation TEXT) RETURNS SMALLINT
 *   get_table_oid(table_name TEXT, schema_name TEXT DEFAULT 'public'::text) RETURNS OID
 *   get_txid_bounds_to_table(table_log_id INTEGER, OUT txid_min INTEGER, OUT txid_max INTEGER) RETURNS RECORD
-*   log_schema_baseline(schemaname TEXT DEFAULT 'public'::text) RETURNS SETOF VOID
-*   log_table_baseline(table_name TEXT, schema_name TEXT DEFAULT 'public'::text) RETURNS SETOF VOID
+*   log_new_table_state(columns TEXT[], table_name TEXT, schema_name TEXT DEFAULT 'public'::text, table_event_key TEXT) RETURNS SETOF VOID
+*   log_old_table_state(columns TEXT[], table_name TEXT, schema_name TEXT DEFAULT 'public'::text, table_event_key TEXT) RETURNS SETOF VOID
+*   log_schema_baseline(schemaname TEXT DEFAULT 'public'::text, include_new BOOLEAN DEFAULT FALSE) RETURNS SETOF VOID
+*   log_table_baseline(table_name TEXT, schema_name TEXT DEFAULT 'public'::text, include_new BOOLEAN DEFAULT FALSE) RETURNS SETOF VOID
 *   log_table_event(event_txid BIGINT, tablename TEXT, schemaname TEXT, op_type TEXT) RETURNS TEXT
-*   log_table_state(columns TEXT[], table_name TEXT, schema_name TEXT DEFAULT 'public'::text, table_event_key TEXT) RETURNS SETOF VOID
 *   register_audit_table(audit_table_name TEXT, audit_schema_name TEXT DEFAULT 'public'::text) RETURNS INTEGER
 *   trim_outer_quotes(quoted_string TEXT) RETURNS TEXT
 *   unregister_audit_table(audit_table_name TEXT, audit_schema_name TEXT DEFAULT 'public'::text) RETURNS SETOF VOID
@@ -541,7 +544,8 @@ LANGUAGE plpgsql STRICT;
 -- create logging triggers for one table
 CREATE OR REPLACE FUNCTION pgmemento.create_table_log_trigger(
   table_name TEXT,
-  schema_name TEXT DEFAULT 'public'::text
+  schema_name TEXT DEFAULT 'public'::text,
+  include_new BOOLEAN DEFAULT FALSE
   ) RETURNS SETOF VOID AS
 $$
 BEGIN
@@ -580,15 +584,15 @@ BEGIN
     EXECUTE format(
       'CREATE TRIGGER log_insert_trigger
          AFTER INSERT ON %I.%I
-         FOR EACH ROW EXECUTE PROCEDURE pgmemento.log_insert()',
-         $2, $1);
+         FOR EACH ROW EXECUTE PROCEDURE pgmemento.log_insert(%s)',
+         $2, $1, CASE WHEN $3 THEN 'log' ELSE '' END);
 
     -- trigger to be fired after update events
     EXECUTE format(
       'CREATE TRIGGER log_update_trigger
          AFTER UPDATE ON %I.%I
-         FOR EACH ROW EXECUTE PROCEDURE pgmemento.log_update()',
-         $2, $1);
+         FOR EACH ROW EXECUTE PROCEDURE pgmemento.log_update(%s)',
+         $2, $1, CASE WHEN $3 THEN 'log' ELSE '' END);
 
     -- trigger to be fired after insert events
     EXECUTE format(
@@ -604,11 +608,12 @@ LANGUAGE plpgsql STRICT;
 -- perform create_table_log_trigger on multiple tables in one schema
 CREATE OR REPLACE FUNCTION pgmemento.create_schema_log_trigger(
   schema_name TEXT DEFAULT 'public'::text,
+  include_new BOOLEAN DEFAULT FALSE,
   except_tables TEXT[] DEFAULT '{}'
   ) RETURNS SETOF VOID AS
 $$
 SELECT
-  pgmemento.create_table_log_trigger(c.relname, $1)
+  pgmemento.create_table_log_trigger(c.relname, $1, $2)
 FROM
   pg_class c,
   pg_namespace n
@@ -616,7 +621,7 @@ WHERE
   c.relnamespace = n.oid
   AND n.nspname = $1
   AND c.relkind = 'r'
-  AND c.relname <> ALL (COALESCE($2,'{}'));
+  AND c.relname <> ALL (COALESCE($3,'{}'));
 $$
 LANGUAGE sql;
 
@@ -777,7 +782,7 @@ WHERE
 $$
 LANGUAGE sql IMMUTABLE STRICT;
 
-CREATE OR REPLACE FUNCTION pgmemento.log_table_state(
+CREATE OR REPLACE FUNCTION pgmemento.log_old_table_state(
   columns TEXT[],
   tablename TEXT,
   schemaname TEXT,
@@ -788,13 +793,42 @@ BEGIN
   IF $1 IS NOT NULL AND array_length($1, 1) IS NOT NULL THEN
     -- log content of given columns
     EXECUTE format(
-      'INSERT INTO pgmemento.row_log(audit_id, event_key, changes)
-         SELECT audit_id, $1, jsonb_build_object('||pgmemento.column_array_to_column_list($1)||') AS content FROM %I.%I ORDER BY audit_id',
+      'INSERT INTO pgmemento.row_log(audit_id, event_key, old_data)
+         SELECT audit_id, $1, jsonb_build_object('||pgmemento.column_array_to_column_list($1)||') AS content
+           FROM %I.%I ORDER BY audit_id',
          $3, $2) USING $4;
   ELSE
     -- log content of entire table
     EXECUTE format(
-      'INSERT INTO pgmemento.row_log (audit_id, event_key, changes)
+      'INSERT INTO pgmemento.row_log (audit_id, event_key, old_data)
+         SELECT audit_id, $1, to_jsonb(%I) AS content FROM %I.%I ORDER BY audit_id',
+         $2, $3, $2) USING $4;
+  END IF;
+END;
+$$
+LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pgmemento.log_new_table_state(
+  columns TEXT[],
+  tablename TEXT,
+  schemaname TEXT,
+  table_event_key TEXT
+  ) RETURNS SETOF VOID AS
+$$
+BEGIN
+  IF $1 IS NOT NULL AND array_length($1, 1) IS NOT NULL THEN
+    -- log content of given columns
+    EXECUTE format(
+      'INSERT INTO pgmemento.row_log(audit_id, event_key, new_data)
+         SELECT audit_id, $1, jsonb_build_object('||pgmemento.column_array_to_column_list($1)||') AS content
+           FROM %I.%I ORDER BY audit_id
+       ON CONFLICT (audit_id, event_key)
+       DO UPDATE SET new_data = excluded.new_data',
+       $3, $2) USING $4;
+  ELSE
+    -- log content of entire table
+    EXECUTE format(
+      'INSERT INTO pgmemento.row_log (audit_id, event_key, new_data)
          SELECT audit_id, $1, to_jsonb(%I) AS content FROM %I.%I ORDER BY audit_id',
          $2, $3, $2) USING $4;
   END IF;
@@ -909,7 +943,7 @@ $$
 BEGIN
   -- log the whole content of the truncated table in the row_log table
   PERFORM
-    pgmemento.log_table_state('{}'::text[], TG_TABLE_NAME, TG_TABLE_SCHEMA, event_key)
+    pgmemento.log_old_table_state('{}'::text[], TG_TABLE_NAME, TG_TABLE_SCHEMA, event_key)
   FROM
     pgmemento.table_event_log
   WHERE
@@ -934,12 +968,22 @@ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION pgmemento.log_insert() RETURNS trigger AS
 $$
 BEGIN
-  -- log inserted row ('changes' column can be left blank)
-  INSERT INTO pgmemento.row_log
-    (audit_id, event_key)
-  VALUES
-    (NEW.audit_id,
-     concat_ws(';', extract(epoch from transaction_timestamp()), extract(epoch from statement_timestamp()), txid_current(), pgmemento.get_operation_id(TG_OP), TG_TABLE_NAME, TG_TABLE_SCHEMA));
+  -- log inserted row ('old_data' column can be left blank)
+  IF TG_ARGV[0] IS NULL THEN
+    INSERT INTO pgmemento.row_log
+      (audit_id, event_key)
+    VALUES
+      (NEW.audit_id,
+       concat_ws(';', extract(epoch from transaction_timestamp()), extract(epoch from statement_timestamp()), txid_current(), pgmemento.get_operation_id(TG_OP), TG_TABLE_NAME, TG_TABLE_SCHEMA));
+  ELSE
+    -- log complete new row as JSONB
+    INSERT INTO pgmemento.row_log
+      (audit_id, event_key, new_data)
+    VALUES
+      (NEW.audit_id,
+       concat_ws(';', extract(epoch from transaction_timestamp()), extract(epoch from statement_timestamp()), txid_current(), pgmemento.get_operation_id(TG_OP), TG_TABLE_NAME, TG_TABLE_SCHEMA),
+       to_json(NEW));
+  END IF;
 
   RETURN NULL;
 END;
@@ -957,7 +1001,8 @@ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION pgmemento.log_update() RETURNS trigger AS
 $$
 DECLARE
-  jsonb_diff JSONB;
+  jsonb_diff_old JSONB;
+  jsonb_diff_new JSONB;
 BEGIN
   -- log values of updated columns for the processed row
   -- therefore, a diff between OLD and NEW is necessary
@@ -967,17 +1012,30 @@ BEGIN
      FROM
        jsonb_each(to_jsonb(OLD))
      WHERE
-      to_jsonb(NEW) ->> key IS DISTINCT FROM to_jsonb(OLD) ->> key
+       to_jsonb(NEW) ->> key IS DISTINCT FROM to_jsonb(OLD) ->> key
     ),
-    '{}')::jsonb INTO jsonb_diff;
+    '{}')::jsonb INTO jsonb_diff_old;
 
-  IF jsonb_diff <> '{}'::jsonb THEN
+  IF TG_ARGV[0] IS NOT NULL THEN
+    -- switch the diff to only get the new values
+    SELECT COALESCE(
+      (SELECT
+         ('{' || string_agg(to_json(key) || ':' || value, ',') || '}')
+       FROM
+         jsonb_each(to_jsonb(NEW))
+       WHERE
+         to_jsonb(OLD) ->> key IS DISTINCT FROM to_jsonb(NEW) ->> key
+      ),
+      '{}')::jsonb INTO jsonb_diff_new;    
+  END IF;
+
+  IF jsonb_diff_old <> '{}'::jsonb OR jsonb_diff_new <> '{}'::jsonb THEN
     INSERT INTO pgmemento.row_log
-      (audit_id, event_key, changes)
+      (audit_id, event_key, old_data, new_data)
     VALUES
       (NEW.audit_id,
        concat_ws(';', extract(epoch from transaction_timestamp()), extract(epoch from statement_timestamp()), txid_current(), pgmemento.get_operation_id(TG_OP), TG_TABLE_NAME, TG_TABLE_SCHEMA),
-       jsonb_diff);
+       jsonb_diff_old, jsonb_diff_new);
   END IF;
 
   RETURN NULL;
@@ -998,7 +1056,7 @@ $$
 BEGIN
   -- log content of the entire row in the row_log table
   INSERT INTO pgmemento.row_log
-    (audit_id, event_key, changes)
+    (audit_id, event_key, old_data)
   VALUES
     (OLD.audit_id,
      concat_ws(';', extract(epoch from transaction_timestamp()), extract(epoch from statement_timestamp()), txid_current(), pgmemento.get_operation_id(TG_OP), TG_TABLE_NAME, TG_TABLE_SCHEMA),
@@ -1018,7 +1076,8 @@ LANGUAGE plpgsql;
 **********************************************************/
 CREATE OR REPLACE FUNCTION pgmemento.log_table_baseline(
   table_name TEXT,
-  schema_name TEXT DEFAULT 'public'::text
+  schema_name TEXT DEFAULT 'public'::text,
+  include_new BOOLEAN DEFAULT FALSE
   ) RETURNS SETOF VOID AS
 $$
 DECLARE
@@ -1056,8 +1115,11 @@ BEGIN
       END IF;
 
       EXECUTE format(
-        'INSERT INTO pgmemento.row_log (audit_id, event_key, changes) '
-         || 'SELECT t.audit_id, $1, NULL::jsonb AS changes '
+        'INSERT INTO pgmemento.row_log (audit_id, event_key'
+         || CASE WHEN $3 THEN ', new_data' ELSE '' END
+         || ') '
+         || 'SELECT t.audit_id, $1'
+         || CASE WHEN $3 THEN ', to_json(t.*) ' ELSE ' ' END
          || 'FROM %I.%I t '
          || 'LEFT JOIN pgmemento.row_log r ON r.audit_id = t.audit_id '
          || 'WHERE r.audit_id IS NULL' || pkey_columns,
@@ -1068,13 +1130,14 @@ END;
 $$
 LANGUAGE plpgsql STRICT;
 
--- perform log_table_state on multiple tables in one schema
+-- perform log_table_baseline on multiple tables in one schema
 CREATE OR REPLACE FUNCTION pgmemento.log_schema_baseline(
-  schemaname TEXT DEFAULT 'public'::text
+  schemaname TEXT DEFAULT 'public'::text,
+  include_new BOOLEAN DEFAULT FALSE
   ) RETURNS SETOF VOID AS
 $$
 SELECT
-  pgmemento.log_table_baseline(a.table_name, a.schema_name)
+  pgmemento.log_table_baseline(a.table_name, a.schema_name, $2)
 FROM
   pgmemento.audit_table_log a,
   pgmemento.audit_tables_dependency d
@@ -1100,19 +1163,20 @@ LANGUAGE sql STRICT;
 CREATE OR REPLACE FUNCTION pgmemento.create_table_audit(
   table_name TEXT,
   schema_name TEXT DEFAULT 'public'::text,
-  log_state BOOLEAN DEFAULT TRUE
+  log_state BOOLEAN DEFAULT TRUE,
+  include_new BOOLEAN DEFAULT FALSE
   ) RETURNS SETOF VOID AS
 $$
 BEGIN
   -- create log trigger
-  PERFORM pgmemento.create_table_log_trigger($1, $2);
+  PERFORM pgmemento.create_table_log_trigger($1, $2, $4);
 
   -- add audit_id column
   PERFORM pgmemento.create_table_audit_id($1, $2);
 
   -- log existing table content as inserted
   IF $3 THEN
-    PERFORM pgmemento.log_table_baseline($1, $2);
+    PERFORM pgmemento.log_table_baseline($1, $2, $4);
   END IF;
 END;
 $$
@@ -1122,11 +1186,12 @@ LANGUAGE plpgsql STRICT;
 CREATE OR REPLACE FUNCTION pgmemento.create_schema_audit(
   schema_name TEXT DEFAULT 'public'::text,
   log_state BOOLEAN DEFAULT TRUE,
+  include_new BOOLEAN DEFAULT FALSE,
   except_tables TEXT[] DEFAULT '{}'
   ) RETURNS SETOF VOID AS
 $$
 SELECT
-  pgmemento.create_table_audit(c.relname, $1, $2)
+  pgmemento.create_table_audit(c.relname, $1, $2, $3)
 FROM
   pg_class c,
   pg_namespace n
@@ -1134,7 +1199,7 @@ WHERE
   c.relnamespace = n.oid
   AND n.nspname = $1
   AND c.relkind = 'r'
-  AND c.relname <> ALL (COALESCE($3,'{}'));
+  AND c.relname <> ALL (COALESCE($4,'{}'));
 $$
 LANGUAGE sql;
 
@@ -1160,7 +1225,7 @@ BEGIN
   -- then either keep the audit trail for table or delete everything
   IF $3 THEN
     -- log the whole content of the table to keep the reference between audit_id and table rows
-    PERFORM pgmemento.log_table_state('{}'::text[], $1, $2, table_event_key);
+    PERFORM pgmemento.log_old_table_state('{}'::text[], $1, $2, table_event_key);
   ELSE
     -- remove all logs related to given table
     PERFORM pgmemento.delete_audit_table_log($1, $2);

--- a/test/SUITE.sql
+++ b/test/SUITE.sql
@@ -59,5 +59,4 @@ VALUES
 \echo 'Uninstall test tables'
 DROP TABLE object;
 
-
 DROP SEQUENCE pgmemento.test_seq;

--- a/test/ddl_log/TEST_ADD_COLUMN.sql
+++ b/test/ddl_log/TEST_ADD_COLUMN.sql
@@ -14,6 +14,7 @@
 -- ChangeLog:
 --
 -- Version | Date       | Description                                    | Author
+-- 0.3.0     2020-03-05   reflect new_data column in row_log               FKun
 -- 0.2.0     2020-01-09   reflect changes on schema and triggers           FKun
 -- 0.1.0     2018-09-20   initial commit                                   FKun
 --
@@ -32,9 +33,11 @@ DECLARE
   test_txid BIGINT := txid_current();
   test_transaction INTEGER;
   test_event TEXT;
+  old_jsonb_log JSONB;
+  new_jsonb_log JSONB;
 BEGIN
   -- add two new columns to tests table
-  ALTER TABLE public.tests ADD COLUMN test_json_column JSON, ADD COLUMN test_tsrange_column tsrange;
+  ALTER TABLE public.tests ADD COLUMN test_json_column JSON DEFAULT '{"test": "value"}'::json, ADD COLUMN test_tsrange_column tsrange;
 
   -- save transaction_id for next tests
   test_transaction := current_setting('pgmemento.' || test_txid)::int;
@@ -64,6 +67,22 @@ BEGIN
     AND op_id = pgmemento.get_operation_id('ADD COLUMN');
 
   ASSERT test_event IS NOT NULL, 'Error: Did not find test entry in table_event_log table!';
+
+  -- query for logged row
+  SELECT
+    old_data,
+    new_data
+  INTO
+    old_jsonb_log,
+    new_jsonb_log
+  FROM
+    pgmemento.row_log
+  WHERE
+    audit_id = current_setting('pgmemento.ddl_test_audit_id')::bigint
+    AND event_key = test_event;
+
+  ASSERT old_jsonb_log IS NULL, 'Error: Wrong old content in row_log table: %', old_jsonb_log;
+  ASSERT new_jsonb_log = ('{"test_json_column": {"test": "value"}, "test_tsrange_column": null}')::jsonb, 'Error: Wrong new content in row_log table: %', new_jsonb_log;
 END;
 $$
 LANGUAGE plpgsql;
@@ -77,6 +96,7 @@ DECLARE
   test_transaction INTEGER;
   colnames TEXT[];
   datatypes TEXT[];
+  defaults TEXT[];
   tid_ranges numrange[];
 BEGIN
   test_transaction := current_setting('pgmemento.add_column_test')::int;
@@ -85,10 +105,12 @@ BEGIN
   SELECT
     array_agg(column_name ORDER BY id),
     array_agg(data_type ORDER BY id),
+    array_agg(column_default ORDER BY id),
     array_agg(txid_range ORDER BY id)
   INTO
     colnames,
     datatypes,
+    defaults,
     tid_ranges
   FROM
     pgmemento.audit_column_log
@@ -99,6 +121,8 @@ BEGIN
   ASSERT colnames[2] = 'test_tsrange_column', 'Did not find column ''%'' in audit_column_log', colnames[2];
   ASSERT datatypes[1] = 'json', 'Data type ''%'' not expected for ''test_json_column''', datatypes[1];
   ASSERT datatypes[2] = 'tsrange', 'Data type ''%'' not expected for ''test_tsrange_column''', datatypes[2];
+  ASSERT defaults[1] = '''{"test": "value"}''::json', 'Column default ''%'' not expected for ''test_json_column''', defaults[1];
+  ASSERT defaults[2] IS NULL, 'Column default ''%'' not expected for ''test_tsrange_column''', defaults[2];
   ASSERT lower(tid_ranges[1]) = test_transaction, 'Error: Starting transaction id % does not match the id % of ADD COLUMN event', lower(tid_ranges[1]), test_transaction;
   ASSERT lower(tid_ranges[2]) = test_transaction, 'Error: Starting transaction id % does not match the id % of ADD COLUMN event', lower(tid_ranges[2]), test_transaction;
 END;

--- a/test/ddl_log/TEST_ALTER_COLUMN.sql
+++ b/test/ddl_log/TEST_ALTER_COLUMN.sql
@@ -14,6 +14,7 @@
 -- ChangeLog:
 --
 -- Version | Date       | Description                                    | Author
+-- 0.3.0     2020-03-05   reflect new_data column in row_log               FKun
 -- 0.2.0     2020-02-29   reflect changes on schema and triggers           FKun
 -- 0.1.1     2018-11-01   reflect range bounds change in audit tables      FKun
 -- 0.1.0     2018-09-20   initial commit                                   FKun
@@ -25,8 +26,15 @@ SELECT nextval('pgmemento.test_seq') AS n \gset
 \echo
 \echo 'TEST ':n': pgMemento audit ALTER TABLE ALTER COLUMN events'
 
--- make dummy insert to check if it's logged when column is altered
-INSERT INTO tests (test_tsrange_column) VALUES (tsrange(now()::timestamp, NULL, '(]')) RETURNING test_tsrange_column AS test_tsrange
+-- set value for range column to check if data is logged when column is altered
+UPDATE
+  tests
+SET
+  test_tsrange_column = tsrange(now()::timestamp, NULL, '(]')
+WHERE
+  audit_id = current_setting('pgmemento.ddl_test_audit_id')::bigint
+RETURNING
+  test_tsrange_column AS test_tsrange
 \gset
 
 -- save inserted value for next test
@@ -218,21 +226,27 @@ $$
 DECLARE
   test_event TEXT;
   test_value TEXT;
-  log_value TEXT;
+  test_value_converted TEXT;
+  old_log_value TEXT;
+  new_log_value TEXT;
 BEGIN
   test_event := current_setting('pgmemento.alter_column_test_event');
   test_value := current_setting('pgmemento.alter_column_test_value');
+  test_value_converted := (tstzrange(lower(test_value::tsrange), upper(test_value::tsrange), '(]'))::text;
 
   SELECT
-    old_data->>'test_tsrange_column'
+    old_data->>'test_tsrange_column',
+    new_data->>'test_tsrange_column'
   INTO
-    log_value
+    old_log_value,
+    new_log_value
   FROM
     pgmemento.row_log
   WHERE
     event_key = test_event;
 
-  ASSERT log_value = test_value, 'Error: Wrong content in row_log table: %', jsonb_log;
+  ASSERT old_log_value = test_value, 'Error: Wrong old content in row_log table: %', old_log_value;
+  ASSERT new_log_value = test_value_converted, 'Error: Wrong new content in row_log table: %', new_log_value;
 END;
 $$
 LANGUAGE plpgsql;

--- a/test/ddl_log/TEST_ALTER_COLUMN.sql
+++ b/test/ddl_log/TEST_ALTER_COLUMN.sql
@@ -14,7 +14,7 @@
 -- ChangeLog:
 --
 -- Version | Date       | Description                                    | Author
--- 0.2.0     2020-01-09   reflect changes on schema and triggers           FKun
+-- 0.2.0     2020-02-29   reflect changes on schema and triggers           FKun
 -- 0.1.1     2018-11-01   reflect range bounds change in audit tables      FKun
 -- 0.1.0     2018-09-20   initial commit                                   FKun
 --
@@ -224,7 +224,7 @@ BEGIN
   test_value := current_setting('pgmemento.alter_column_test_value');
 
   SELECT
-    changes->>'test_tsrange_column'
+    old_data->>'test_tsrange_column'
   INTO
     log_value
   FROM

--- a/test/ddl_log/TEST_CREATE_TABLE.sql
+++ b/test/ddl_log/TEST_CREATE_TABLE.sql
@@ -14,6 +14,7 @@
 -- ChangeLog:
 --
 -- Version | Date       | Description                                    | Author
+-- 0.2.1     2020-03-05   insert dummy tuple for subsequent tests          FKun
 -- 0.2.0     2020-01-09   reflect changes on schema and triggers           FKun
 -- 0.1.0     2018-07-17   initial commit                                   FKun
 --
@@ -157,3 +158,15 @@ BEGIN
 END;
 $$
 LANGUAGE plpgsql;
+
+-- create one test row
+INSERT INTO
+  public.test (test_column)
+VALUES
+  ('test')
+RETURNING
+  audit_id AS ddl_audit_id
+\gset
+
+-- save table log id for next test
+SELECT set_config('pgmemento.ddl_test_audit_id', :ddl_audit_id::text, FALSE);

--- a/test/ddl_log/TEST_DROP_COLUMN.sql
+++ b/test/ddl_log/TEST_DROP_COLUMN.sql
@@ -14,7 +14,7 @@
 -- ChangeLog:
 --
 -- Version | Date       | Description                                    | Author
--- 0.2.0     2020-01-09   reflect changes on schema and triggers           FKun
+-- 0.2.0     2020-02-29   reflect changes on schema and triggers           FKun
 -- 0.1.0     2018-09-24   initial commit                                   FKun
 --
 
@@ -120,7 +120,7 @@ BEGIN
   test_event := current_setting('pgmemento.drop_column_test_event');
 
   SELECT
-    changes
+    old_data
   INTO
     jsonb_log
   FROM

--- a/test/ddl_log/TEST_DROP_COLUMN.sql
+++ b/test/ddl_log/TEST_DROP_COLUMN.sql
@@ -128,7 +128,7 @@ BEGIN
   WHERE
     event_key = test_event;
 
-  ASSERT jsonb_log->>'test_column' IS NULL, 'Error: Wrong content in row_log table: %', jsonb_log;
+  ASSERT jsonb_log->>'test_column' = 'test', 'Error: Wrong content in row_log table: %', jsonb_log;
   ASSERT jsonb_log->>'test_tstzrange_column' IS NOT NULL, 'Error: Wrong content in row_log table: %', jsonb_log;
 END;
 $$

--- a/test/ddl_log/TEST_DROP_TABLE.sql
+++ b/test/ddl_log/TEST_DROP_TABLE.sql
@@ -169,7 +169,7 @@ BEGIN
 
   ASSERT (jsonb_log->>'id')::bigint = 1, 'Error: Wrong content in row_log table: %', jsonb_log->>'id';
   ASSERT jsonb_log->>'test_geom_column' IS NULL, 'Error: Wrong content in row_log table: %', jsonb_log->>'test_geom_column';
-  ASSERT jsonb_log->>'test_json_column' IS NULL, 'Error: Wrong content in row_log table: %', jsonb_log->>'test_json_column';
+  ASSERT jsonb_log->>'test_json_column' = '{"test": "value"}', 'Error: Wrong content in row_log table: %', jsonb_log->>'test_json_column';
   ASSERT (jsonb_log->>'audit_id')::bigint = log_audit_id, 'Error: Audit_ids do not match: Expected %, found %', log_audit_id, jsonb_log->>'audit_id';
 END;
 $$

--- a/test/ddl_log/TEST_DROP_TABLE.sql
+++ b/test/ddl_log/TEST_DROP_TABLE.sql
@@ -14,7 +14,7 @@
 -- ChangeLog:
 --
 -- Version | Date       | Description                                    | Author
--- 0.2.0     2020-01-09   reflect changes on schema and triggers           FKun
+-- 0.2.0     2020-02-29   reflect changes on schema and triggers           FKun
 -- 0.1.0     2018-09-25   initial commit                                   FKun
 --
 
@@ -158,7 +158,7 @@ BEGIN
 
   SELECT
     audit_id,
-    changes
+    old_data
   INTO
     log_audit_id,
     jsonb_log

--- a/test/dml_log/TEST_DELETE.sql
+++ b/test/dml_log/TEST_DELETE.sql
@@ -14,6 +14,7 @@
 -- ChangeLog:
 --
 -- Version | Date       | Description                                    | Author
+-- 0.3.0     2020-03-05   reflect new_data column in row_log               FKun
 -- 0.2.0     2020-02-29   reflect changes on schema and triggers           FKun
 -- 0.1.0     2017-11-19   initial commit                                   FKun
 --
@@ -34,7 +35,8 @@ DECLARE
   test_txid BIGINT := txid_current();
   test_event TEXT;
   delete_op_id SMALLINT := pgmemento.get_operation_id('DELETE');
-  jsonb_log JSONB;
+  old_jsonb_log JSONB;
+  new_jsonb_log JSONB;
 BEGIN
   -- DELETE entry that has been inserted for other tests
   DELETE FROM public.object
@@ -69,16 +71,19 @@ BEGIN
 
   -- query for logged row
   SELECT
-    old_data
+    old_data,
+    new_data
   INTO
-    jsonb_log
+    old_jsonb_log,
+    new_jsonb_log
   FROM
     pgmemento.row_log
   WHERE
     audit_id = delete_audit_id
     AND event_key = test_event;
 
-  ASSERT jsonb_log = ('{"id": '||delete_id||', "lineage": "pgm_update_test", "audit_id": '||delete_audit_id||'}')::jsonb, 'Error: Wrong content in row_log table: %' jsonb_log;
+  ASSERT old_jsonb_log = ('{"id": '||delete_id||', "lineage": "pgm_update_test", "audit_id": '||delete_audit_id||'}')::jsonb, 'Error: Wrong old content in row_log table: %' old_jsonb_log;
+  ASSERT new_jsonb_log IS NULL, 'Error: Wrong new content in row_log table: %' new_jsonb_log;
 END;
 $$
 LANGUAGE plpgsql;

--- a/test/dml_log/TEST_DELETE.sql
+++ b/test/dml_log/TEST_DELETE.sql
@@ -14,7 +14,7 @@
 -- ChangeLog:
 --
 -- Version | Date       | Description                                    | Author
--- 0.2.0     2020-01-09   reflect changes on schema and triggers           FKun
+-- 0.2.0     2020-02-29   reflect changes on schema and triggers           FKun
 -- 0.1.0     2017-11-19   initial commit                                   FKun
 --
 
@@ -69,7 +69,7 @@ BEGIN
 
   -- query for logged row
   SELECT
-    changes
+    old_data
   INTO
     jsonb_log
   FROM

--- a/test/dml_log/TEST_INSERT.sql
+++ b/test/dml_log/TEST_INSERT.sql
@@ -15,7 +15,7 @@
 -- ChangeLog:
 --
 -- Version | Date       | Description                                    | Author
--- 0.2.0     2020-01-09   reflect changes on schema and triggers           FKun
+-- 0.2.0     2020-02-29   reflect changes on schema and triggers           FKun
 -- 0.1.2     2018-11-10   reflect changes in SETUP                         FKun
 -- 0.1.1     2017-11-20   added upsert case                                FKun
 -- 0.1.0     2017-11-18   initial commit                                   FKun
@@ -134,7 +134,7 @@ BEGIN
 
   -- query for logged row
   SELECT
-    changes
+    old_data
   INTO
     jsonb_log
   FROM
@@ -209,7 +209,7 @@ BEGIN
 
   -- query for logged row
   SELECT
-    array_agg(r.changes ORDER BY r.id NULLS FIRST)
+    array_agg(r.old_data ORDER BY r.id NULLS FIRST)
   INTO
     jsonb_log
   FROM

--- a/test/dml_log/TEST_INSERT.sql
+++ b/test/dml_log/TEST_INSERT.sql
@@ -15,6 +15,7 @@
 -- ChangeLog:
 --
 -- Version | Date       | Description                                    | Author
+-- 0.3.0     2020-03-05   reflect new_data column in row_log               FKun
 -- 0.2.0     2020-02-29   reflect changes on schema and triggers           FKun
 -- 0.1.2     2018-11-10   reflect changes in SETUP                         FKun
 -- 0.1.1     2017-11-20   added upsert case                                FKun
@@ -36,7 +37,7 @@ DECLARE
   test_event TEXT;
 BEGIN
   -- create baseline for test table
-  PERFORM pgmemento.log_table_baseline('object', 'public');
+  PERFORM pgmemento.log_table_baseline('object', 'public', TRUE);
 
   -- query for logged transaction
   ASSERT (
@@ -88,11 +89,13 @@ LANGUAGE plpgsql;
 DO
 $$
 DECLARE
+  insert_id INTEGER;
   insert_audit_id INTEGER; 
   test_txid BIGINT := txid_current();
   test_event TEXT;
   insert_op_id SMALLINT := pgmemento.get_operation_id('INSERT');
-  jsonb_log JSONB;
+  old_jsonb_log JSONB;
+  new_jsonb_log JSONB;
 BEGIN
   -- set session_info to query logged transaction later
   PERFORM set_config('pgmemento.session_info', '{"message":"Live insert test"}'::text, TRUE);
@@ -103,9 +106,9 @@ BEGIN
   VALUES
     (2, 'pgm_insert_test')
   RETURNING
-    audit_id
+    id, audit_id
   INTO
-    insert_audit_id;
+    insert_id, insert_audit_id;
 
   -- query for logged transaction
   ASSERT (
@@ -134,16 +137,19 @@ BEGIN
 
   -- query for logged row
   SELECT
-    old_data
+    old_data,
+    new_data
   INTO
-    jsonb_log
+    old_jsonb_log,
+    new_jsonb_log
   FROM
     pgmemento.row_log
   WHERE
     audit_id = insert_audit_id
     AND event_key = test_event;
 
-  ASSERT jsonb_log IS NULL, 'Error: Wrong content in row_log table: %', jsonb_log;
+  ASSERT old_jsonb_log IS NULL, 'Error: Wrong old content in row_log table: %', old_jsonb_log;
+  ASSERT new_jsonb_log = ('{"id": '||insert_id||', "lineage": "pgm_insert_test", "audit_id": '||insert_audit_id||'}')::jsonb, 'Error: Wrong new content in row_log table: %', new_jsonb_log;
 END;
 $$
 LANGUAGE plpgsql;
@@ -158,7 +164,8 @@ DECLARE
   upsert_audit_id INTEGER;
   test_txid BIGINT := txid_current();
   event_keys TEXT[];
-  jsonb_log JSONB[];
+  old_jsonb_log JSONB[];
+  new_jsonb_log JSONB[];
 BEGIN
   -- get audit_id of inserted row
   SELECT
@@ -209,17 +216,21 @@ BEGIN
 
   -- query for logged row
   SELECT
-    array_agg(r.old_data ORDER BY r.id NULLS FIRST)
+    array_agg(r.old_data ORDER BY r.id NULLS FIRST),
+    array_agg(r.new_data ORDER BY r.id NULLS FIRST)
   INTO
-    jsonb_log
+    old_jsonb_log,
+    new_jsonb_log
   FROM
     unnest(event_keys) AS e(key)
   LEFT JOIN
     pgmemento.row_log r
     ON e.key = r.event_key;
 
-  ASSERT jsonb_log[1] IS NULL, 'Error: INSERT event should not be logged: %', jsonb_log[1];
-  ASSERT jsonb_log[2] = '{"lineage":"pgm_insert_test"}'::jsonb, 'Error: Wrong content in row_log table: %', jsonb_log[2];
+  ASSERT old_jsonb_log[1] IS NULL, 'Error: INSERT event should not be logged: %', old_jsonb_log[1];
+  ASSERT old_jsonb_log[2] = '{"lineage":"pgm_insert_test"}'::jsonb, 'Error: Wrong old content in row_log table: %', old_jsonb_log[2];
+  ASSERT new_jsonb_log[1] IS NULL, 'Error: INSERT event should not be logged: %', new_jsonb_log[1];
+  ASSERT new_jsonb_log[2] = '{"lineage":"pgm_upsert_test"}'::jsonb, 'Error: Wrong new content in row_log table: %', new_jsonb_log[2];
 END;
 $$
 LANGUAGE plpgsql;

--- a/test/dml_log/TEST_UPDATE.sql
+++ b/test/dml_log/TEST_UPDATE.sql
@@ -14,7 +14,7 @@
 -- ChangeLog:
 --
 -- Version | Date       | Description                                    | Author
--- 0.2.0     2020-01-09   reflect changes on schema and triggers           FKun
+-- 0.2.0     2020-02-29   reflect changes on schema and triggers           FKun
 -- 0.1.0     2017-11-19   initial commit                                   FKun
 --
 
@@ -124,7 +124,7 @@ BEGIN
 
   -- query for logged row
   SELECT
-    changes
+    old_data
   INTO
     jsonb_log
   FROM

--- a/test/dml_log/TEST_UPDATE.sql
+++ b/test/dml_log/TEST_UPDATE.sql
@@ -14,6 +14,7 @@
 -- ChangeLog:
 --
 -- Version | Date       | Description                                    | Author
+-- 0.3.0     2020-03-05   reflect new_data column in row_log               FKun
 -- 0.2.0     2020-02-29   reflect changes on schema and triggers           FKun
 -- 0.1.0     2017-11-19   initial commit                                   FKun
 --
@@ -90,7 +91,8 @@ DECLARE
   test_txid BIGINT := txid_current();
   test_event TEXT;
   update_op_id SMALLINT := pgmemento.get_operation_id('UPDATE');
-  jsonb_log JSONB;
+  old_jsonb_log JSONB;
+  new_jsonb_log JSONB;
 BEGIN
   -- UPDATE entry that has been inserted during INSERT test
   UPDATE public.object SET lineage = 'pgm_update_test'
@@ -124,16 +126,19 @@ BEGIN
 
   -- query for logged row
   SELECT
-    old_data
+    old_data,
+    new_data
   INTO
-    jsonb_log
+    old_jsonb_log,
+    new_jsonb_log
   FROM
     pgmemento.row_log
   WHERE
     audit_id = update_audit_id
     AND event_key = test_event;
 
-  ASSERT jsonb_log = '{"lineage":"pgm_upsert_test"}'::jsonb, 'Error: Wrong content in row_log table: %' jsonb_log;
+  ASSERT old_jsonb_log = '{"lineage":"pgm_upsert_test"}'::jsonb, 'Error: Wrong old content in row_log table: %' old_jsonb_log;
+  ASSERT new_jsonb_log = '{"lineage":"pgm_update_test"}'::jsonb, 'Error: Wrong new content in row_log table: %' new_jsonb_log;
 END;
 $$
 LANGUAGE plpgsql;

--- a/test/restore/TEST_RESTORE_RECORD.sql
+++ b/test/restore/TEST_RESTORE_RECORD.sql
@@ -32,7 +32,7 @@ DECLARE
   column_list TEXT;
 BEGIN
   SELECT
-    pgmemento.restore_record_definition(16, 'object', 'public')
+    pgmemento.restore_record_definition(17, 'object', 'public')
   INTO
     column_list;
 
@@ -49,7 +49,7 @@ LANGUAGE plpgsql;
 DO
 $$
 DECLARE
-  query_sring TEXT := 'SELECT * FROM pgmemento.restore_record(1, 16, ''object'', ''public'', 3)';
+  query_sring TEXT := 'SELECT * FROM pgmemento.restore_record(1, 17, ''object'', ''public'', 3)';
   rec RECORD;
 BEGIN
   -- append saved column list to query string

--- a/test/restore/TEST_RESTORE_RECORDS.sql
+++ b/test/restore/TEST_RESTORE_RECORDS.sql
@@ -32,7 +32,7 @@ DECLARE
   column_list TEXT;
 BEGIN
   SELECT
-    pgmemento.restore_record_definition(1, 18, log_id)
+    pgmemento.restore_record_definition(1, 19, log_id)
   INTO
     column_list
   FROM
@@ -54,7 +54,7 @@ LANGUAGE plpgsql;
 DO
 $$
 DECLARE
-  query_sring TEXT := 'SELECT array_agg(lineage) FROM pgmemento.restore_records(1, 18, ''object'', ''public'', 3)';
+  query_sring TEXT := 'SELECT array_agg(lineage) FROM pgmemento.restore_records(1, 19, ''object'', ''public'', 3)';
   lineage_values TEXT[];
   jsonb_log JSONB;
 BEGIN
@@ -73,18 +73,18 @@ BEGIN
   INTO
     jsonb_log
   FROM
-    pgmemento.restore_records(1, 18, 'object', 'public', 3, TRUE)
+    pgmemento.restore_records(1, 19, 'object', 'public', 3, TRUE)
     AS (log JSONB);
 
   ASSERT jsonb_log->0->>'lineage' = 'pgm_insert_test', 'Incorrect historic value for ''lineage'' column. Expected ''pgm_insert_test'', but found %', jsonb_log->0->>'lineage';
   ASSERT jsonb_log->0->>'table_operation' = 'INSERT' , 'Incorrect historic value for ''table_operation''. Expected ''INSERT'', but found %', jsonb_log->0->>'table_operation';
-  ASSERT jsonb_log->0->>'transaction_id' = '13', 'Incorrect historic value for ''transaction_id'' column. Expected 13, but found %', jsonb_log->0->>'transaction_id';
+  ASSERT jsonb_log->0->>'transaction_id' = '14', 'Incorrect historic value for ''transaction_id'' column. Expected 14, but found %', jsonb_log->0->>'transaction_id';
   ASSERT jsonb_log->1->>'lineage' = 'pgm_upsert_test', 'Incorrect historic value for ''lineage'' column. Expected ''pgm_upsert_test'', but found %', jsonb_log->1->>'lineage';
   ASSERT jsonb_log->1->>'table_operation' = 'UPDATE' , 'Incorrect historic value for ''table_operation''. Expected ''UPDATE'', but found %', jsonb_log->1->>'table_operation';
-  ASSERT jsonb_log->1->>'transaction_id' = '14', 'Incorrect historic value for ''transaction_id'' column. Expected 14, but found %', jsonb_log->1->>'transaction_id';
+  ASSERT jsonb_log->1->>'transaction_id' = '15', 'Incorrect historic value for ''transaction_id'' column. Expected 15, but found %', jsonb_log->1->>'transaction_id';
   ASSERT jsonb_log->2->>'lineage' = 'pgm_update_test', 'Incorrect historic value for ''lineage'' column. Expected ''pgm_update_test'', but found %', jsonb_log->2->>'lineage';
   ASSERT jsonb_log->2->>'table_operation' = 'UPDATE' , 'Incorrect historic value for ''table_operation''. Expected ''UPDATE'', but found %', jsonb_log->2->>'table_operation';
-  ASSERT jsonb_log->2->>'transaction_id' = '17', 'Incorrect historic value for ''transaction_id'' column. Expected 17, but found %', jsonb_log->2->>'transaction_id';
+  ASSERT jsonb_log->2->>'transaction_id' = '18', 'Incorrect historic value for ''transaction_id'' column. Expected 18, but found %', jsonb_log->2->>'transaction_id';
 END;
 $$
 LANGUAGE plpgsql;

--- a/test/restore/TEST_RESTORE_RECORDSET.sql
+++ b/test/restore/TEST_RESTORE_RECORDSET.sql
@@ -36,7 +36,7 @@ BEGIN
   INTO
     lineage_values
   FROM
-    pgmemento.restore_recordset(1, 18, 'object', 'public')
+    pgmemento.restore_recordset(1, 19, 'object', 'public')
     AS (id integer, lineage text, audit_id bigint);
 
   ASSERT lineage_values[1] = 'init', 'Incorrect historic value for ''lineage'' column. Expected ''init'', but found %', lineage_values[1];
@@ -48,7 +48,7 @@ BEGIN
   INTO
     jsonb_log
   FROM
-    pgmemento.restore_recordset(1, 18, 'object', 'public', TRUE)
+    pgmemento.restore_recordset(1, 19, 'object', 'public', TRUE)
     AS (log JSONB);
 
   ASSERT jsonb_log->0 = '{"id": 1, "lineage": "init", "audit_id": 1}'::jsonb, 'Incorrect historic record. Expected JSON ''{"id": 1, "lineage": "init", "audit_id": 1}'', but found %', jsonb_log->0;

--- a/test/restore/TEST_RESTORE_RECORDSETS.sql
+++ b/test/restore/TEST_RESTORE_RECORDSETS.sql
@@ -44,7 +44,7 @@ BEGIN
     operations,
     txids
   FROM
-    pgmemento.restore_recordsets(1, 18, 'object', 'public')
+    pgmemento.restore_recordsets(1, 19, 'object', 'public')
     AS (id integer, lineage text, audit_id bigint, stmt_time timestamp with time zone, table_operation text, transaction_id integer);
 
   ASSERT audit_ids[1] = 1, 'Expected audit_id 1, but found %', audit_ids[1];
@@ -54,10 +54,10 @@ BEGIN
   ASSERT operations[2] = 'INSERT', 'Expected ''INSERT'', but founds %', operations[2];
   ASSERT operations[3] = 'UPDATE', 'Expected ''UPDATE'', but founds %', operations[3];
   ASSERT operations[4] = 'UPDATE', 'Expected ''UPDATE'', but founds %', operations[4];
-  ASSERT txids[1] = 12, 'Expected transaction id 12, but found %', txids[1];
-  ASSERT txids[2] = 13, 'Expected transaction id 13, but found %', txids[2];
-  ASSERT txids[3] = 14, 'Expected transaction id 14, but found %', txids[3];
-  ASSERT txids[4] = 17, 'Expected transaction id 17, but found %', txids[4];
+  ASSERT txids[1] = 13, 'Expected transaction id 13, but found %', txids[1];
+  ASSERT txids[2] = 14, 'Expected transaction id 14, but found %', txids[2];
+  ASSERT txids[3] = 15, 'Expected transaction id 15, but found %', txids[3];
+  ASSERT txids[4] = 18, 'Expected transaction id 18, but found %', txids[4];
 
   -- restore row as JSONB
   SELECT
@@ -65,25 +65,25 @@ BEGIN
   INTO
     jsonb_log
   FROM
-    pgmemento.restore_recordsets(1, 18, 'object', 'public', TRUE)
+    pgmemento.restore_recordsets(1, 19, 'object', 'public', TRUE)
     AS (log JSONB);
 
   ASSERT jsonb_log->0->>'id' = '1', 'Incorrect historic value for ''id'' column. Expected 1, but found %', jsonb_log->0->>'id';
   ASSERT jsonb_log->0->>'lineage' = 'init', 'Incorrect historic value for ''lineage'' column. Expected ''init'', but found %', jsonb_log->0->>'lineage';
   ASSERT jsonb_log->0->>'audit_id' = '1', 'Incorrect historic value for ''audit_id'' column. Expected 1, but found %', jsonb_log->0->>'id';
   ASSERT jsonb_log->0->>'table_operation' = 'INSERT' , 'Incorrect historic value for ''table_operation''. Expected ''INSERT'', but found %', jsonb_log->0->>'table_operation';
-  ASSERT jsonb_log->0->>'transaction_id' = '12', 'Incorrect historic value for ''transaction_id'' column. Expected 12, but found %', jsonb_log->0->>'transaction_id'; 
+  ASSERT jsonb_log->0->>'transaction_id' = '13', 'Incorrect historic value for ''transaction_id'' column. Expected 13, but found %', jsonb_log->0->>'transaction_id'; 
   ASSERT jsonb_log->1->>'id' = '2', 'Incorrect historic value for ''id'' column. Expected 2, but found %', jsonb_log->1->>'id';
   ASSERT jsonb_log->1->>'lineage' = 'pgm_insert_test', 'Incorrect historic value for ''lineage'' column. Expected ''pgm_insert_test'', but found %', jsonb_log->1->>'lineage';
   ASSERT jsonb_log->1->>'audit_id' = '3', 'Incorrect historic value for ''audit_id'' column. Expected 3, but found %', jsonb_log->1->>'id';
   ASSERT jsonb_log->1->>'table_operation' = 'INSERT' , 'Incorrect historic value for ''table_operation''. Expected ''INSERT'', but found %', jsonb_log->1->>'table_operation';
-  ASSERT jsonb_log->1->>'transaction_id' = '13', 'Incorrect historic value for ''transaction_id'' column. Expected 13, but found %', jsonb_log->1->>'transaction_id';
+  ASSERT jsonb_log->1->>'transaction_id' = '14', 'Incorrect historic value for ''transaction_id'' column. Expected 14, but found %', jsonb_log->1->>'transaction_id';
   ASSERT jsonb_log->2->>'lineage' = 'pgm_upsert_test', 'Incorrect historic value for ''lineage'' column. Expected ''pgm_upsert_test'', but found %', jsonb_log->2->>'lineage';
   ASSERT jsonb_log->2->>'table_operation' = 'UPDATE' , 'Incorrect historic value for ''table_operation''. Expected ''UPDATE'', but found %', jsonb_log->2->>'table_operation';
-  ASSERT jsonb_log->2->>'transaction_id' = '14', 'Incorrect historic value for ''transaction_id'' column. Expected 14, but found %', jsonb_log->2->>'transaction_id';
+  ASSERT jsonb_log->2->>'transaction_id' = '15', 'Incorrect historic value for ''transaction_id'' column. Expected 15, but found %', jsonb_log->2->>'transaction_id';
   ASSERT jsonb_log->3->>'lineage' = 'pgm_update_test', 'Incorrect historic value for ''lineage'' column. Expected ''pgm_update_test'', but found %', jsonb_log->3->>'lineage';
   ASSERT jsonb_log->3->>'table_operation' = 'UPDATE' , 'Incorrect historic value for ''table_operation''. Expected ''UPDATE'', but found %', jsonb_log->3->>'table_operation';
-  ASSERT jsonb_log->3->>'transaction_id' = '17', 'Incorrect historic value for ''transaction_id'' column. Expected 17, but found %', jsonb_log->3->>'transaction_id';
+  ASSERT jsonb_log->3->>'transaction_id' = '18', 'Incorrect historic value for ''transaction_id'' column. Expected 18, but found %', jsonb_log->3->>'transaction_id';
 END;
 $$
 LANGUAGE plpgsql;

--- a/test/revert/TEST_REVERT_ADD_COLUMN.sql
+++ b/test/revert/TEST_REVERT_ADD_COLUMN.sql
@@ -41,7 +41,9 @@ BEGIN
     pgmemento.table_event_log
   WHERE
     op_id = pgmemento.get_operation_id('ADD COLUMN')
-    AND transaction_id = 5;
+  ORDER BY
+    id
+  LIMIT 1;
 
   -- query for logged transaction
   SELECT

--- a/test/revert/TEST_REVERT_CREATE_TABLE.sql
+++ b/test/revert/TEST_REVERT_CREATE_TABLE.sql
@@ -41,8 +41,10 @@ BEGIN
   FROM
     pgmemento.table_event_log
   WHERE
-    op_id = pgmemento.get_operation_id('CREATE TABLE')
-    AND transaction_id = 2;
+    table_operation = 'CREATE TABLE'
+  ORDER BY
+    id
+  LIMIT 1;
 
   -- query for logged transaction
   SELECT

--- a/test/revert/TEST_REVERT_DELETE.sql
+++ b/test/revert/TEST_REVERT_DELETE.sql
@@ -14,7 +14,7 @@
 -- ChangeLog:
 --
 -- Version | Date       | Description                                    | Author
--- 0.2.0     2020-01-09   reflect changes on schema and triggers           FKun
+-- 0.2.0     2020-02-29   reflect changes on schema and triggers           FKun
 -- 0.1.0     2018-10-18   initial commit                                   FKun
 --
 
@@ -83,7 +83,7 @@ BEGIN
         ON t.audit_id = r.audit_id 
       WHERE
         r.event_key = test_event
-        AND r.changes IS NULL
+        AND r.old_data IS NULL
     )
   ),
   'Error: Entries of test table were not entirely logged in row_log table!';

--- a/test/revert/TEST_REVERT_INSERT.sql
+++ b/test/revert/TEST_REVERT_INSERT.sql
@@ -14,7 +14,7 @@
 -- ChangeLog:
 --
 -- Version | Date       | Description                                    | Author
--- 0.2.0     2020-01-09   reflect changes on schema and triggers           FKun
+-- 0.2.0     2020-02-29   reflect changes on schema and triggers           FKun
 -- 0.1.0     2018-10-20   initial commit                                   FKun
 --
 
@@ -89,7 +89,7 @@ BEGIN
         pgmemento.row_log 
       WHERE
         event_key = test_event
-        AND changes = jsonb_log
+        AND old_data = jsonb_log
     )
   ),
   'Error: Entries of test table were not entirely logged in row_log table!';

--- a/test/revert/TEST_REVERT_TRUNCATE.sql
+++ b/test/revert/TEST_REVERT_TRUNCATE.sql
@@ -14,7 +14,7 @@
 -- ChangeLog:
 --
 -- Version | Date       | Description                                    | Author
--- 0.2.0     2020-01-09   reflect changes on schema and triggers           FKun
+-- 0.2.0     2020-02-29   reflect changes on schema and triggers           FKun
 -- 0.1.0     2018-10-18   initial commit                                   FKun
 --
 
@@ -83,7 +83,7 @@ BEGIN
         ON t.audit_id = r.audit_id 
       WHERE
         r.event_key = test_event
-        AND r.changes IS NULL
+        AND r.old_data IS NULL
     )
   ),
   'Error: Entries of test table were not entirely logged in row_log table!';

--- a/test/revert/TEST_REVERT_UPDATE.sql
+++ b/test/revert/TEST_REVERT_UPDATE.sql
@@ -14,7 +14,7 @@
 -- ChangeLog:
 --
 -- Version | Date       | Description                                    | Author
--- 0.2.0     2020-01-09   reflect changes on schema and triggers           FKun
+-- 0.2.0     2020-02-29   reflect changes on schema and triggers           FKun
 -- 0.1.0     2018-10-19   initial commit                                   FKun
 --
 
@@ -96,7 +96,7 @@ BEGIN
         ON t.audit_id = r.audit_id 
       WHERE
         r.event_key = test_event
-        AND r.changes = jsonb_log
+        AND r.old_data = jsonb_log
     )
   ),
   'Error: Entries of test table were not logged correctly in row_log table!';

--- a/test/setup/TEST_INIT.sql
+++ b/test/setup/TEST_INIT.sql
@@ -14,6 +14,7 @@
 -- ChangeLog:
 --
 -- Version | Date       | Description                                    | Author
+-- 0.3.0     2020-03-05   reflect new_data column in row_log               FKun
 -- 0.2.0     2017-09-08   moved drop parts to TEST_UNINSTALL.sql           FKun
 -- 0.1.0     2017-07-20   initial commit                                   FKun
 --
@@ -30,7 +31,7 @@ DO
 $$
 BEGIN
   -- create the event triggers
-  PERFORM pgmemento.create_schema_event_trigger(TRUE);
+  PERFORM pgmemento.create_schema_event_trigger(TRUE, TRUE);
 
   -- query for event triggers
   ASSERT (
@@ -41,8 +42,9 @@ BEGIN
         VALUES
           ('schema_drop_pre_trigger'),
           ('table_alter_post_trigger'),
+          ('table_alter_post_trigger_full'),
           ('table_alter_pre_trigger'),
-          ('table_create_post_trigger'),
+          ('table_create_post_trigger_full'),
           ('table_drop_post_trigger'),
           ('table_drop_pre_trigger')
         ) AS p (pgm_event_trigger)
@@ -69,7 +71,7 @@ DECLARE
   tab TEXT := 'object';
 BEGIN
   -- create log trigger
-  PERFORM pgmemento.create_table_log_trigger(tab, 'public');
+  PERFORM pgmemento.create_table_log_trigger(tab, 'public', TRUE);
 
   -- query for log trigger
   ASSERT (

--- a/test/setup/TEST_INSTALL.sql
+++ b/test/setup/TEST_INSTALL.sql
@@ -14,7 +14,7 @@
 -- ChangeLog:
 --
 -- Version | Date       | Description                                    | Author
--- 0.1.1     2019-10-21   reflect all changes of 0.7 release               FKun
+-- 0.2.0     2020-02-29   reflect all changes of 0.7 release               FKun
 -- 0.1.0     2017-07-20   initial commit                                   FKun
 --
 
@@ -101,17 +101,17 @@ BEGIN
     p.pronamespace = n.oid
     AND n.nspname = 'pgmemento';
 
-  ASSERT array_length(pgm_objects,1) = 84, 'Error: Incorrect number of stored procedures!';
+  ASSERT array_length(pgm_objects,1) = 88, 'Error: Incorrect number of stored procedures!';
   ASSERT pgm_objects[1] = 'audit_table_check;record;tid integer, tab_name text, tab_schema text, OUT table_log_id integer, OUT log_tab_name text, OUT log_tab_schema text, OUT log_tab_id integer, OUT recent_tab_name text, OUT recent_tab_schema text, OUT recent_tab_id integer', 'Error: Expected different function and/or arguments';
   ASSERT pgm_objects[2] = 'column_array_to_column_list;text;columns text[]', 'Error: Expected different function and/or arguments';
   ASSERT pgm_objects[3] = 'create_restore_template;SETOF void;until_tid integer, template_name text, table_name text, schema_name text DEFAULT ''public''::text, preserve_template boolean DEFAULT false', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[4] = 'create_schema_audit;SETOF void;schema_name text DEFAULT ''public''::text, log_state boolean DEFAULT true, except_tables text[] DEFAULT ''{}''::text[]', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[4] = 'create_schema_audit;SETOF void;schema_name text DEFAULT ''public''::text, log_state boolean DEFAULT true, include_new boolean DEFAULT false, except_tables text[] DEFAULT ''{}''::text[]', 'Error: Expected different function and/or arguments';
   ASSERT pgm_objects[5] = 'create_schema_audit_id;SETOF void;schema_name text DEFAULT ''public''::text, except_tables text[] DEFAULT ''{}''::text[]', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[6] = 'create_schema_event_trigger;SETOF void;trigger_create_table boolean DEFAULT false', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[7] = 'create_schema_log_trigger;SETOF void;schema_name text DEFAULT ''public''::text, except_tables text[] DEFAULT ''{}''::text[]', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[8] = 'create_table_audit;SETOF void;table_name text, schema_name text DEFAULT ''public''::text, log_state boolean DEFAULT true', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[6] = 'create_schema_event_trigger;SETOF void;trigger_create_table boolean DEFAULT false, include_new boolean DEFAULT false', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[7] = 'create_schema_log_trigger;SETOF void;schema_name text DEFAULT ''public''::text, include_new boolean DEFAULT false, except_tables text[] DEFAULT ''{}''::text[]', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[8] = 'create_table_audit;SETOF void;table_name text, schema_name text DEFAULT ''public''::text, log_state boolean DEFAULT true, include_new boolean DEFAULT false', 'Error: Expected different function and/or arguments';
   ASSERT pgm_objects[9] = 'create_table_audit_id;SETOF void;table_name text, schema_name text DEFAULT ''public''::text', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[10] = 'create_table_log_trigger;SETOF void;table_name text, schema_name text DEFAULT ''public''::text', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[10] = 'create_table_log_trigger;SETOF void;table_name text, schema_name text DEFAULT ''public''::text, include_new boolean DEFAULT false', 'Error: Expected different function and/or arguments';
   ASSERT pgm_objects[11] = 'delete_audit_table_log;SETOF integer;tablename text, schemaname text DEFAULT ''public''::text', 'Error: Expected different function and/or arguments';
   ASSERT pgm_objects[12] = 'delete_key;SETOF bigint;aid bigint, key_name text, old_value anyelement', 'Error: Expected different function and/or arguments';
   ASSERT pgm_objects[13] = 'delete_table_event_log;SETOF integer;tid integer, tablename text, schemaname text DEFAULT ''public''::text', 'Error: Expected different function and/or arguments';
@@ -146,46 +146,50 @@ BEGIN
   ASSERT pgm_objects[42] = 'jsonb_unroll_for_update;text;path text, nested_value jsonb, complex_typname text', 'Error: Expected different function and/or arguments';
   ASSERT pgm_objects[43] = 'log_delete;trigger', 'Error: Expected different function and/or arguments';
   ASSERT pgm_objects[44] = 'log_insert;trigger', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[45] = 'log_schema_baseline;SETOF void;schemaname text DEFAULT ''public''::text', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[46] = 'log_table_baseline;SETOF void;table_name text, schema_name text DEFAULT ''public''::text', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[47] = 'log_table_event;text;event_txid bigint, tablename text, schemaname text, op_type text', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[48] = 'log_table_state;SETOF void;columns text[], tablename text, schemaname text, table_event_key text', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[49] = 'log_transaction;trigger', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[50] = 'log_truncate;trigger', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[51] = 'log_update;trigger', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[52] = 'modify_ddl_log_tables;SETOF void;tablename text, schemaname text', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[53] = 'move_schema_state;SETOF void;target_schema_name text, source_schema_name text DEFAULT ''public''::text, except_tables text[] DEFAULT ''{}''::text[], copy_data boolean DEFAULT true', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[54] = 'move_table_state;SETOF void;table_name text, target_schema_name text, source_schema_name text, copy_data boolean DEFAULT true', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[55] = 'pkey_schema_state;SETOF void;target_schema_name text, original_schema_name text DEFAULT ''public''::text, except_tables text[] DEFAULT ''{}''::text[]', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[56] = 'pkey_table_state;SETOF void;table_name text, target_schema_name text, original_schema_name text DEFAULT ''public''::text', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[57] = 'recover_audit_version;SETOF void;tid integer, aid bigint, changes jsonb, table_op integer, table_name text, schema_name text DEFAULT ''public''::text', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[58] = 'register_audit_table;integer;audit_table_name text, audit_schema_name text DEFAULT ''public''::text', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[59] = 'restore_change;anyelement;during_tid integer, aid bigint, column_name text, INOUT restored_value anyelement', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[60] = 'restore_query;text;start_from_tid integer, end_at_tid integer, table_name text, schema_name text DEFAULT ''public''::text, aid bigint DEFAULT NULL::bigint, all_versions boolean DEFAULT false', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[61] = 'restore_record;SETOF record;start_from_tid integer, end_at_tid integer, table_name text, schema_name text, aid bigint, jsonb_output boolean DEFAULT false', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[62] = 'restore_record_definition;text;tid integer, table_name text, schema_name text DEFAULT ''public''::text', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[63] = 'restore_record_definition;text;start_from_tid integer, end_at_tid integer, table_log_id integer', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[64] = 'restore_records;SETOF record;start_from_tid integer, end_at_tid integer, table_name text, schema_name text, aid bigint, jsonb_output boolean DEFAULT false', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[65] = 'restore_recordset;SETOF record;start_from_tid integer, end_at_tid integer, table_name text, schema_name text DEFAULT ''public''::text, jsonb_output boolean DEFAULT false', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[66] = 'restore_recordsets;SETOF record;start_from_tid integer, end_at_tid integer, table_name text, schema_name text DEFAULT ''public''::text, jsonb_output boolean DEFAULT false', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[67] = 'restore_schema_state;SETOF void;start_from_tid integer, end_at_tid integer, original_schema_name text, target_schema_name text, target_table_type text DEFAULT ''VIEW''::text, update_state boolean DEFAULT false', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[68] = 'restore_table_state;SETOF void;start_from_tid integer, end_at_tid integer, original_table_name text, original_schema_name text, target_schema_name text, target_table_type text DEFAULT ''VIEW''::text, update_state boolean DEFAULT false', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[69] = 'restore_value;anyelement;until_tid integer, aid bigint, column_name text, INOUT restored_value anyelement', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[70] = 'revert_distinct_transaction;SETOF void;tid integer', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[71] = 'revert_distinct_transactions;SETOF void;start_from_tid integer, end_at_tid integer', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[72] = 'revert_transaction;SETOF void;tid integer', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[73] = 'revert_transactions;SETOF void;start_from_tid integer, end_at_tid integer', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[74] = 'schema_drop_pre_trigger;event_trigger', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[75] = 'sequence_schema_state;SETOF void;target_schema_name text, original_schema_name text DEFAULT ''public''::text', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[76] = 'split_table_from_query;record;INOUT query text, OUT audit_table_name text, OUT audit_schema_name text, OUT audit_table_log_id integer', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[77] = 'table_alter_post_trigger;event_trigger', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[78] = 'table_alter_pre_trigger;event_trigger', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[79] = 'table_create_post_trigger;event_trigger', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[80] = 'table_drop_post_trigger;event_trigger', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[81] = 'table_drop_pre_trigger;event_trigger', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[82] = 'trim_outer_quotes;text;quoted_string text', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[83] = 'unregister_audit_table;SETOF void;audit_table_name text, audit_schema_name text DEFAULT ''public''::text', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[84] = 'update_key;SETOF bigint;aid bigint, path_to_key_name text[], old_value anyelement, new_value anyelement', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[45] = 'log_new_table_state;SETOF void;columns text[], tablename text, schemaname text, table_event_key text', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[46] = 'log_old_table_state;SETOF void;columns text[], tablename text, schemaname text, table_event_key text', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[47] = 'log_schema_baseline;SETOF void;schemaname text DEFAULT ''public''::text, include_new boolean DEFAULT false', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[48] = 'log_table_baseline;SETOF void;table_name text, schema_name text DEFAULT ''public''::text, include_new boolean DEFAULT false', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[49] = 'log_table_event;text;event_txid bigint, tablename text, schemaname text, op_type text', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[50] = 'log_transaction;trigger', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[51] = 'log_truncate;trigger', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[52] = 'log_update;trigger', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[53] = 'modify_ddl_log_tables;SETOF void;tablename text, schemaname text', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[54] = 'modify_row_log;SETOF void;tablename text, schemaname text', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[55] = 'move_schema_state;SETOF void;target_schema_name text, source_schema_name text DEFAULT ''public''::text, except_tables text[] DEFAULT ''{}''::text[], copy_data boolean DEFAULT true', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[56] = 'move_table_state;SETOF void;table_name text, target_schema_name text, source_schema_name text, copy_data boolean DEFAULT true', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[57] = 'pkey_schema_state;SETOF void;target_schema_name text, original_schema_name text DEFAULT ''public''::text, except_tables text[] DEFAULT ''{}''::text[]', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[58] = 'pkey_table_state;SETOF void;table_name text, target_schema_name text, original_schema_name text DEFAULT ''public''::text', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[59] = 'recover_audit_version;SETOF void;tid integer, aid bigint, changes jsonb, table_op integer, table_name text, schema_name text DEFAULT ''public''::text', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[60] = 'register_audit_table;integer;audit_table_name text, audit_schema_name text DEFAULT ''public''::text', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[61] = 'restore_change;anyelement;during_tid integer, aid bigint, column_name text, INOUT restored_value anyelement', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[62] = 'restore_query;text;start_from_tid integer, end_at_tid integer, table_name text, schema_name text DEFAULT ''public''::text, aid bigint DEFAULT NULL::bigint, all_versions boolean DEFAULT false', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[63] = 'restore_record;SETOF record;start_from_tid integer, end_at_tid integer, table_name text, schema_name text, aid bigint, jsonb_output boolean DEFAULT false', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[64] = 'restore_record_definition;text;tid integer, table_name text, schema_name text DEFAULT ''public''::text', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[65] = 'restore_record_definition;text;start_from_tid integer, end_at_tid integer, table_log_id integer', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[66] = 'restore_records;SETOF record;start_from_tid integer, end_at_tid integer, table_name text, schema_name text, aid bigint, jsonb_output boolean DEFAULT false', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[67] = 'restore_recordset;SETOF record;start_from_tid integer, end_at_tid integer, table_name text, schema_name text DEFAULT ''public''::text, jsonb_output boolean DEFAULT false', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[68] = 'restore_recordsets;SETOF record;start_from_tid integer, end_at_tid integer, table_name text, schema_name text DEFAULT ''public''::text, jsonb_output boolean DEFAULT false', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[69] = 'restore_schema_state;SETOF void;start_from_tid integer, end_at_tid integer, original_schema_name text, target_schema_name text, target_table_type text DEFAULT ''VIEW''::text, update_state boolean DEFAULT false', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[70] = 'restore_table_state;SETOF void;start_from_tid integer, end_at_tid integer, original_table_name text, original_schema_name text, target_schema_name text, target_table_type text DEFAULT ''VIEW''::text, update_state boolean DEFAULT false', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[71] = 'restore_value;anyelement;until_tid integer, aid bigint, column_name text, INOUT restored_value anyelement', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[72] = 'revert_distinct_transaction;SETOF void;tid integer', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[73] = 'revert_distinct_transactions;SETOF void;start_from_tid integer, end_at_tid integer', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[74] = 'revert_transaction;SETOF void;tid integer', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[75] = 'revert_transactions;SETOF void;start_from_tid integer, end_at_tid integer', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[76] = 'schema_drop_pre_trigger;event_trigger', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[77] = 'sequence_schema_state;SETOF void;target_schema_name text, original_schema_name text DEFAULT ''public''::text', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[78] = 'split_table_from_query;record;INOUT query text, OUT audit_table_name text, OUT audit_schema_name text, OUT audit_table_log_id integer', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[79] = 'table_alter_post_trigger;event_trigger', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[80] = 'table_alter_post_trigger_full;event_trigger', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[81] = 'table_alter_pre_trigger;event_trigger', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[82] = 'table_create_post_trigger;event_trigger', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[83] = 'table_create_post_trigger_full;event_trigger', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[84] = 'table_drop_post_trigger;event_trigger', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[85] = 'table_drop_pre_trigger;event_trigger', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[86] = 'trim_outer_quotes;text;quoted_string text', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[87] = 'unregister_audit_table;SETOF void;audit_table_name text, audit_schema_name text DEFAULT ''public''::text', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[88] = 'update_key;SETOF bigint;aid bigint, path_to_key_name text[], old_value anyelement, new_value anyelement', 'Error: Expected different function and/or arguments';
 END;
 $$
 LANGUAGE plpgsql;


### PR DESCRIPTION
- Adds column `new_data` to `row_log` table
- Renames column `changes` of `row_log` table to `old_data`
- New argument `include_new` for procedures creating triggers
- Renames `log_table_state` procedure to `log_old_table_state` as there is also `log_new_table_state`
- New event triggers to log new data from added / altered columns
- Changes index on `event_key` of `row_log` table to UNIQUE index with `audit_id` to upsert new values for ALTER COLUMN events

closes #43 