### PR TITLE
set password for docker run

### DIFF
--- a/extension/tests/container.sh
+++ b/extension/tests/container.sh
@@ -8,7 +8,7 @@ PG_VERSION=$1
 TESTCMD=$2
 
 docker build -t pgmemento-test--$PG_VERSION - < ./Dockerfile-$PG_VERSION;
-CONTAINER=$(docker run -d -v $(pwd)/../..:/home/pgmemento pgmemento-test--$PG_VERSION);
+CONTAINER=$(docker run -d -e POSTGRES_PASSWORD=password -v $(pwd)/../..:/home/pgmemento pgmemento-test--$PG_VERSION);
 
 echo "Waiting for 10 seconds to let the database init before we roll";
 sleep 10;


### PR DESCRIPTION
postgres docker image now requires to define a password or set auth method to trust.
See [issue](https://github.com/docker-library/postgres/issues/681)