### PR TITLE
add drop endpoint and more fixes in CTL.sql

### DIFF
--- a/UPGRADE_v061_to_v07.sql
+++ b/UPGRADE_v061_to_v07.sql
@@ -163,6 +163,8 @@ DROP FUNCTION IF EXISTS pgmemento.create_schema_log_trigger(schema_name TEXT, ex
 
 DROP FUNCTION IF EXISTS pgmemento.create_table_log_trigger(table_name TEXT, schema_name TEXT);
 
+DROP FUNCTION IF EXISTS pgmemento.drop_schema_audit(schema_name TEXT, keep_log BOOLEAN, except_tables TEXT[]);
+
 DROP FUNCTION IF EXISTS pgmemento.drop_table_audit(table_name TEXT, schema_name TEXT, keep_log BOOLEAN);
 
 DROP AGGREGATE IF EXISTS pgmemento.jsonb_merge(jsonb);

--- a/src/CTL.sql
+++ b/src/CTL.sql
@@ -14,6 +14,7 @@
 -- ChangeLog:
 --
 -- Version | Date       | Description                                  | Author
+-- 0.3.1     2020-04-11   add drop endpoint                              FKun
 -- 0.3.0     2020-03-29   make logging of old data configurable, too     FKun
 -- 0.2.0     2020-03-21   write changes to audit_schema_log              FKun
 -- 0.1.0     2020-03-15   initial commit                                 FKun
@@ -23,19 +24,20 @@
 * C-o-n-t-e-n-t:
 *
 * FUNCTIONS:
-*   init(schema_name TEXT DEFAULT 'public'::text, audit_id_column_name TEXT DEFAULT 'pgmemento_audit_id'::text,
+*   drop(schemaname TEXT DEFAULT 'public'::text, keep_log BOOLEAN DEFAULT TRUE, except_tables TEXT[] DEFAULT '{}') RETURNS TEXT
+*   init(schemaname TEXT DEFAULT 'public'::text, audit_id_column_name TEXT DEFAULT 'pgmemento_audit_id'::text,
 *     log_old_data BOOLEAN DEFAULT TRUE, log_new_data BOOLEAN DEFAULT FALSE, log_state BOOLEAN DEFAULT FALSE,
 *     trigger_create_table BOOLEAN DEFAULT FALSE, except_tables TEXT[] DEFAULT '{}') RETURNS TEXT
-*   start(schema_name TEXT DEFAULT 'public'::text, audit_id_column_name TEXT DEFAULT 'pgmemento_audit_id'::text,
+*   start(schemaname TEXT DEFAULT 'public'::text, audit_id_column_name TEXT DEFAULT 'pgmemento_audit_id'::text,
 *     log_old_data BOOLEAN DEFAULT TRUE, log_new_data BOOLEAN DEFAULT FALSE, trigger_create_table BOOLEAN DEFAULT FALSE,
 *     except_tables TEXT[] DEFAULT '{}') RETURNS TEXT
-*   stop(schema_name TEXT DEFAULT 'public'::text, except_tables TEXT[] DEFAULT '{}') RETURNS TEXT
+*   stop(schemaname TEXT DEFAULT 'public'::text, except_tables TEXT[] DEFAULT '{}') RETURNS TEXT
 *   version(OUT full_version TEXT, OUT major_version INTEGER, OUT minor_version INTEGER, OUT build_id TEXT) RETURNS RECORD
 *
 ***********************************************************/
 
 CREATE OR REPLACE FUNCTION pgmemento.init(
-  schema_name TEXT DEFAULT 'public'::text,
+  schemaname TEXT DEFAULT 'public'::text,
   audit_id_column_name TEXT DEFAULT 'pgmemento_audit_id'::text,
   log_old_data BOOLEAN DEFAULT TRUE,
   log_new_data BOOLEAN DEFAULT FALSE,
@@ -51,11 +53,10 @@ BEGIN
   -- and store configuration in session_info object
   PERFORM set_config(
     'pgmemento.session_info',
-    format('{"pgmemento_init": {"schema_name", %L, "default_audit_id_column", %L, "default_log_old_data": %L, "default_log_new_data": %L, "log_state": %L, "trigger_create_table": %L, "except_tables": %L}}',
+    format('{"pgmemento_init": {"schema_name": %L, "default_audit_id_column": %L, "default_log_old_data": %L, "default_log_new_data": %L, "log_state": %L, "trigger_create_table": %L, "except_tables": %L}}',
     to_jsonb($1), to_jsonb($2), to_jsonb($3), to_jsonb($4), to_jsonb($5), to_jsonb($6), to_jsonb($7))::text,
     TRUE
   );
-
   txid_log_id := pgmemento.log_transaction(txid_current());
 
   -- insert new entry in audit_schema_log
@@ -77,7 +78,7 @@ $$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION pgmemento.start(
-  schema_name TEXT DEFAULT 'public'::text,
+  schemaname TEXT DEFAULT 'public'::text,
   audit_id_column_name TEXT DEFAULT 'pgmemento_audit_id'::text,
   log_old_data BOOLEAN DEFAULT TRUE,
   log_new_data BOOLEAN DEFAULT FALSE,
@@ -98,7 +99,9 @@ BEGIN
     pgmemento.audit_schema_log
   WHERE
     schema_name = $1
-    AND upper(txid_range) IS NULL;
+  ORDER BY
+    id DESC
+  LIMIT 1;
 
   IF current_audit_schema_log.id IS NULL THEN
     RETURN format('pgMemento is not yet intialized on %s schema. Run init first.', $1);
@@ -108,11 +111,10 @@ BEGIN
   -- and store configuration in session_info object
   PERFORM set_config(
     'pgmemento.session_info',
-     format('{"pgmemento_start": {"schema_name", %L, "default_audit_id_column": %L, "default_log_old_data": %L, "default_log_new_data": %L, "trigger_create_table": %L, "except_tables": %L}}',
+     format('{"pgmemento_start": {"schema_name": %L, "default_audit_id_column": %L, "default_log_old_data": %L, "default_log_new_data": %L, "trigger_create_table": %L, "except_tables": %L}}',
        to_jsonb($1), to_jsonb($2), to_jsonb($3), to_jsonb($4), to_jsonb($5), to_jsonb($6))::text,
      TRUE
   );
-
   txid_log_id := pgmemento.log_transaction(txid_current());
 
   IF upper(current_audit_schema_log.txid_range) IS NULL THEN
@@ -121,7 +123,7 @@ BEGIN
        OR current_audit_schema_log.default_log_new_data != $4
        OR current_audit_schema_log.trigger_create_table != $5
     THEN
-      UPDATE pgmementp.audit_schema_log
+      UPDATE pgmemento.audit_schema_log
          SET txid_range = numrange(lower(txid_range), txid_log_id::numeric, '(]')
        WHERE id = current_audit_schema_log.id;
     ELSE
@@ -137,17 +139,17 @@ BEGIN
      numrange(txid_log_id, NULL, '(]'));
 
   -- enable triggers where they are not active
-  SELECT
-    pgmemento.create_table_log_trigger(c.relname, $1, atl.audit_id_column, $3)
+  PERFORM
+    pgmemento.create_table_log_trigger(c.relname, $1, at.audit_id_column, $3)
   FROM
     pg_class c
   JOIN
     pg_namespace n
     ON c.relnamespace = n.oid
-  JOIN pgmemento.audit_table_log atl
-    ON atl.table_name = c.relname
-   AND atl.schema_name = n.nspname
-   AND upper(atl.txid_range) IS NOT NULL
+  JOIN pgmemento.audit_tables at
+    ON at.tablename = c.relname
+   AND at.schemaname = n.nspname
+   AND NOT tg_is_active
   WHERE
     n.nspname = $1
     AND c.relkind = 'r'
@@ -164,30 +166,34 @@ $$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION pgmemento.stop(
-  schema_name TEXT DEFAULT 'public'::text,
+  schemaname TEXT DEFAULT 'public'::text,
   except_tables TEXT[] DEFAULT '{}'
   ) RETURNS TEXT AS
 $$
 DECLARE
-  current_audit_schema_log pgmemento.audit_schema_log%ROWTYPE;
-  txid_log_id INTEGER;
+  current_schema_log_id INTEGER;
+  current_schema_log_range numrange;
 BEGIN
   -- check if schema is already logged
   SELECT
-    *
+    id,
+    txid_range
   INTO
-    current_audit_schema_log
+    current_schema_log_id,
+    current_schema_log_range
   FROM
     pgmemento.audit_schema_log
   WHERE
     schema_name = $1
-    AND upper(txid_range) IS NULL;
+  ORDER BY
+    id DESC
+  LIMIT 1;
 
-  IF current_audit_schema_log.id IS NULL THEN
+  IF current_schema_log_id IS NULL THEN
     RETURN format('pgMemento is not intialized on %s schema.', $1);
   END IF;
 
-  IF upper(current_audit_schema_log.txid_range) IS NOT NULL THEN
+  IF upper(current_schema_log_range) IS NOT NULL THEN
     RETURN format('pgMemento is already stopped on %s schema.', $1);
   END IF;
 
@@ -195,18 +201,13 @@ BEGIN
   -- and store configuration in session_info object
   PERFORM set_config(
     'pgmemento.session_info',
-     format('{"pgmemento_stop": {"schema_name", %L, "except_tables": %L}}',
+     format('{"pgmemento_stop": {"schema_name": %L, "except_tables": %L}}',
        to_jsonb($1), to_jsonb($2))::text,
      TRUE
   );
+  PERFORM pgmemento.log_transaction(txid_current());
 
-  txid_log_id := pgmemento.log_transaction(txid_current());
-
-  -- close txid_range for audit_schema_log entry
-  UPDATE pgmementp.audit_schema_log
-     SET txid_range = numrange(lower(txid_range), txid_log_id::numeric, '(]')
-   WHERE id = current_audit_schema_log.id;
-
+  -- drop log triggers for all tables except those from passed array
   PERFORM pgmemento.drop_schema_log_trigger($1, $2);
 
   IF $2 IS NOT NULL AND array_length($2, 1) > 0 THEN
@@ -219,22 +220,80 @@ BEGIN
          AND at.schemaname = $1
        WHERE tg_is_active
     ) THEN
-      -- create new entry in audit_schema_log
-      INSERT INTO pgmemento.audit_schema_log
-        (log_id, schema_name, default_audit_id_column, default_log_new_data, default_log_old_data, trigger_create_table, txid_range)
-      VALUES
-        (current_audit_schema_log.log_id, $1,
-         current_audit_schema_log.default_audit_id_column,
-         current_audit_schema_log.default_log_old_data,
-         current_audit_schema_log.default_log_new_data,
-         current_audit_schema_log.trigger_create_table,
-         numrange(txid_log_id, NULL, '(]'));
-
       RETURN format('pgMemento is partly stopped on %s schema.', $1);
     END IF;
   END IF;
 
   RETURN format('pgMemento is stopped on %s schema.', $1);
+END;
+$$
+LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pgmemento.drop(
+  schemaname TEXT DEFAULT 'public'::text,
+  keep_log BOOLEAN DEFAULT TRUE,
+  except_tables TEXT[] DEFAULT '{}'
+  ) RETURNS TEXT AS
+$$
+DECLARE
+  current_schema_log_id INTEGER;
+  current_schema_log_range numrange;
+  txid_log_id INTEGER;
+BEGIN
+  -- check if schema is already logged
+  SELECT
+    id,
+    txid_range
+  INTO
+    current_schema_log_id,
+    current_schema_log_range
+  FROM
+    pgmemento.audit_schema_log
+  WHERE
+    schema_name = $1
+  ORDER BY
+    id DESC
+  LIMIT 1;
+
+  IF current_schema_log_id IS NULL THEN
+    RETURN format('pgMemento is not intialized on %s schema.', $1);
+  END IF;
+
+  -- log transaction that drops pgMemento from a schema
+  -- and store configuration in session_info object
+  PERFORM set_config(
+    'pgmemento.session_info',
+     format('{"pgmemento_drop": {"schema_name": %L, "keep_log": %L ,"except_tables": %L}}',
+       to_jsonb($1), to_jsonb($2), to_jsonb($3))::text,
+     TRUE
+  );
+  txid_log_id := pgmemento.log_transaction(txid_current());
+
+  -- drop auditing for all tables except those from passed array
+  PERFORM pgmemento.drop_schema_audit($1, $2, $3);
+
+  IF $3 IS NOT NULL AND array_length($3, 1) > 0 THEN
+    -- check if excluded tables are still audited
+    IF EXISTS (
+      SELECT 1
+        FROM pgmemento.audited_tables at
+        JOIN unnest($3) AS t(audit_table)
+          ON t.audit_table = at.tablename
+         AND at.schemaname = $1
+       WHERE tg_is_active
+    ) THEN
+      RETURN format('pgMemento is partly dropped from %s schema.', $1);
+    END IF;
+  END IF;
+
+  IF upper(current_schema_log_range) IS NULL THEN
+    -- close txid_range for audit_schema_log entry
+    UPDATE pgmemento.audit_schema_log
+       SET txid_range = numrange(lower(txid_range), txid_log_id::numeric, '(]')
+     WHERE id = current_schema_log_id;
+  END IF;
+
+  RETURN format('pgMemento is dropped from %s schema.', $1);
 END;
 $$
 LANGUAGE plpgsql;
@@ -246,6 +305,6 @@ CREATE OR REPLACE FUNCTION pgmemento.version(
   OUT build_id TEXT
   ) RETURNS RECORD AS
 $$
-SELECT 'pgMemento 0.7'::text AS full_version, 0 AS major_version, 7 AS minor_version, '48'::text AS build_id;
+SELECT 'pgMemento 0.7'::text AS full_version, 0 AS major_version, 7 AS minor_version, '49'::text AS build_id;
 $$
 LANGUAGE sql;

--- a/test/SUITE.sql
+++ b/test/SUITE.sql
@@ -52,7 +52,8 @@ VALUES
 \i test/restore/TEST_RESTORE_RECORDSETS.sql;
 \i test/restore/TEST_RESTORE_TABLE_STATE.sql;
 
--- test uninstalling everything
+-- test CTL functions and uninstalling
+\i test/setup/TEST_STOP_START.sql
 \i test/setup/TEST_UNINSTALL.sql
 
 \echo

--- a/test/setup/TEST_INSTALL.sql
+++ b/test/setup/TEST_INSTALL.sql
@@ -13,9 +13,9 @@
 --
 -- ChangeLog:
 --
--- Version | Date       | Description                                    | Author
--- 0.2.0     2020-02-29   reflect all changes of 0.7 release               FKun
--- 0.1.0     2017-07-20   initial commit                                   FKun
+-- Version | Date       | Description                                  | Author
+-- 0.2.0     2020-02-29   reflect all changes of 0.7 release             FKun
+-- 0.1.0     2017-07-20   initial commit                                 FKun
 --
 
 -- get test number
@@ -104,7 +104,7 @@ BEGIN
     p.pronamespace = n.oid
     AND n.nspname = 'pgmemento';
 
-  ASSERT array_length(pgm_objects,1) = 91, 'Error: Incorrect number of stored procedures!';
+  ASSERT array_length(pgm_objects,1) = 92, 'Error: Incorrect number of stored procedures!';
   ASSERT pgm_objects[1] = 'audit_table_check;record;tid integer, tab_name text, tab_schema text, OUT table_log_id integer, OUT log_tab_name text, OUT log_tab_schema text, OUT log_audit_id_column text, OUT log_tab_id integer, OUT recent_tab_name text, OUT recent_tab_schema text, OUT recent_audit_id_column text, OUT recent_tab_id integer', 'Error: Expected different function and/or arguments';
   ASSERT pgm_objects[2] = 'column_array_to_column_list;text;columns text[]', 'Error: Expected different function and/or arguments';
   ASSERT pgm_objects[3] = 'create_restore_template;SETOF void;until_tid integer, template_name text, table_name text, schema_name text DEFAULT ''public''::text, preserve_template boolean DEFAULT false', 'Error: Expected different function and/or arguments';
@@ -112,7 +112,7 @@ BEGIN
   ASSERT pgm_objects[5] = 'create_schema_audit_id;SETOF void;schemaname text DEFAULT ''public''::text, except_tables text[] DEFAULT ''{}''::text[]', 'Error: Expected different function and/or arguments';
   ASSERT pgm_objects[6] = 'create_schema_event_trigger;SETOF void;trigger_create_table boolean DEFAULT false', 'Error: Expected different function and/or arguments';
   ASSERT pgm_objects[7] = 'create_schema_log_trigger;SETOF void;schemaname text DEFAULT ''public''::text, log_old_data boolean DEFAULT true, log_new_data boolean DEFAULT false, except_tables text[] DEFAULT ''{}''::text[]', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[8] = 'create_table_audit;SETOF void;table_name text, schema_name text DEFAULT ''public''::text, audit_id_column_name text DEFAULT ''pgmemento_audit_id''::text, log_old_data boolean DEFAULT true, log_new_data boolean DEFAULT false, log_state boolean DEFAULT false', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[8] = 'create_table_audit;SETOF void;tablename text, schemaname text DEFAULT ''public''::text, audit_id_column_name text DEFAULT ''pgmemento_audit_id''::text, log_old_data boolean DEFAULT true, log_new_data boolean DEFAULT false, log_state boolean DEFAULT false', 'Error: Expected different function and/or arguments';
   ASSERT pgm_objects[9] = 'create_table_audit_id;SETOF void;table_name text, schema_name text DEFAULT ''public''::text, audit_id_column_name text DEFAULT ''pgmemento_audit_id''::text', 'Error: Expected different function and/or arguments';
   ASSERT pgm_objects[10] = 'create_table_log_trigger;SETOF void;table_name text, schema_name text DEFAULT ''public''::text, audit_id_column_name text DEFAULT ''pgmemento_audit_id''::text, log_old_data boolean DEFAULT true, log_new_data boolean DEFAULT false', 'Error: Expected different function and/or arguments';
   ASSERT pgm_objects[11] = 'delete_audit_table_log;SETOF integer;tablename text, schemaname text DEFAULT ''public''::text', 'Error: Expected different function and/or arguments';
@@ -120,82 +120,83 @@ BEGIN
   ASSERT pgm_objects[13] = 'delete_table_event_log;SETOF integer;tid integer, tablename text, schemaname text DEFAULT ''public''::text', 'Error: Expected different function and/or arguments';
   ASSERT pgm_objects[14] = 'delete_table_event_log;SETOF integer;tablename text, schemaname text DEFAULT ''public''::text', 'Error: Expected different function and/or arguments';
   ASSERT pgm_objects[15] = 'delete_txid_log;integer;tid integer', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[16] = 'drop_schema_audit;SETOF void;schema_name text DEFAULT ''public''::text, keep_log boolean DEFAULT true, except_tables text[] DEFAULT ''{}''::text[]', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[17] = 'drop_schema_audit_id;SETOF void;schema_name text DEFAULT ''public''::text, except_tables text[] DEFAULT ''{}''::text[]', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[18] = 'drop_schema_event_trigger;SETOF void', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[19] = 'drop_schema_log_trigger;SETOF void;schema_name text DEFAULT ''public''::text, except_tables text[] DEFAULT ''{}''::text[]', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[20] = 'drop_schema_state;SETOF void;target_schema_name text, except_tables text[] DEFAULT ''{}''::text[]', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[21] = 'drop_table_audit;SETOF void;table_name text, schema_name text DEFAULT ''public''::text, audit_id_column_name text DEFAULT ''pgmemento_audit_id''::text, keep_log boolean DEFAULT true', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[22] = 'drop_table_audit_id;SETOF void;table_name text, schema_name text DEFAULT ''public''::text, audit_id_column_name text DEFAULT ''pgmemento_audit_id''::text', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[23] = 'drop_table_log_trigger;SETOF void;table_name text, schema_name text DEFAULT ''public''::text', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[24] = 'drop_table_state;SETOF void;table_name text, target_schema_name text DEFAULT ''public''::text', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[25] = 'fetch_ident;text;context text, fetch_count integer DEFAULT 1', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[26] = 'fkey_schema_state;SETOF void;target_schema_name text, original_schema_name text DEFAULT ''public''::text, except_tables text[] DEFAULT ''{}''::text[]', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[27] = 'fkey_table_state;SETOF void;table_name text, target_schema_name text, original_schema_name text DEFAULT ''public''::text', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[28] = 'flatten_ddl;text;ddl_command text', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[29] = 'get_column_list_by_txid;SETOF record;tid integer, table_name text, schema_name text DEFAULT ''public''::text, OUT column_name text, OUT data_type text, OUT ordinal_position integer', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[30] = 'get_column_list_by_txid_range;SETOF record;start_from_tid integer, end_at_tid integer, table_log_id integer, OUT column_name text, OUT column_count integer, OUT data_type text, OUT ordinal_position integer, OUT txid_range numrange', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[31] = 'get_ddl_from_context;text;stack text', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[32] = 'get_max_txid_to_audit_id;integer;aid bigint', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[33] = 'get_min_txid_to_audit_id;integer;aid bigint', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[34] = 'get_operation_id;smallint;operation text', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[35] = 'get_table_oid;oid;table_name text, schema_name text DEFAULT ''public''::text', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[36] = 'get_txid_bounds_to_table;record;table_log_id integer, OUT txid_min integer, OUT txid_max integer', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[37] = 'get_txids_to_audit_id;SETOF integer;aid bigint', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[38] = 'index_schema_state;SETOF void;target_schema_name text, original_schema_name text DEFAULT ''public''::text, except_tables text[] DEFAULT ''{}''::text[]', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[39] = 'index_table_state;SETOF void;table_name text, target_schema_name text, original_schema_name text DEFAULT ''public''::text', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[40] = 'init;text;schema_name text DEFAULT ''public''::text, audit_id_column_name text DEFAULT ''pgmemento_audit_id''::text, log_old_data boolean DEFAULT true, log_new_data boolean DEFAULT false, log_state boolean DEFAULT false, trigger_create_table boolean DEFAULT false, except_tables text[] DEFAULT ''{}''::text[]', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[41] = 'jsonb_merge;jsonb;jsonb', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[42] = 'jsonb_populate_value;anyelement;jsonb_log jsonb, column_name text, INOUT template anyelement', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[43] = 'jsonb_unroll_for_update;text;path text, nested_value jsonb, complex_typname text', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[44] = 'log_delete;trigger', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[45] = 'log_insert;trigger', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[46] = 'log_new_table_state;SETOF void;columns text[], tablename text, schemaname text, table_event_key text, audit_id_column_name text DEFAULT ''pgmemento_audit_id''::text', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[47] = 'log_old_table_state;SETOF void;columns text[], tablename text, schemaname text, table_event_key text, audit_id_column_name text DEFAULT ''pgmemento_audit_id''::text', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[48] = 'log_schema_baseline;SETOF void;audit_schema_name text DEFAULT ''public''::text', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[49] = 'log_statement;trigger', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[50] = 'log_table_baseline;SETOF void;table_name text, schema_name text DEFAULT ''public''::text, audit_id_column_name text DEFAULT ''pgmemento_audit_id''::text, log_new_data boolean DEFAULT false', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[51] = 'log_table_event;text;event_txid bigint, tablename text, schemaname text, op_type text', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[52] = 'log_transaction;integer;current_txid bigint', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[53] = 'log_truncate;trigger', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[54] = 'log_update;trigger', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[55] = 'modify_ddl_log_tables;SETOF void;tablename text, schemaname text', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[56] = 'modify_row_log;SETOF void;tablename text, schemaname text, audit_id_column_name text DEFAULT ''pgmemento_audit_id''::text', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[57] = 'move_schema_state;SETOF void;target_schema_name text, source_schema_name text DEFAULT ''public''::text, except_tables text[] DEFAULT ''{}''::text[], copy_data boolean DEFAULT true', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[58] = 'move_table_state;SETOF void;table_name text, target_schema_name text, source_schema_name text, copy_data boolean DEFAULT true', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[59] = 'pkey_schema_state;SETOF void;target_schema_name text, original_schema_name text DEFAULT ''public''::text, except_tables text[] DEFAULT ''{}''::text[]', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[60] = 'pkey_table_state;SETOF void;target_table_name text, target_schema_name text, original_schema_name text DEFAULT ''public''::text', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[61] = 'recover_audit_version;SETOF void;tid integer, aid bigint, changes jsonb, table_op integer, table_name text, schema_name text DEFAULT ''public''::text, audit_id_column_name text DEFAULT ''pgmemento_audit_id''::text', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[62] = 'register_audit_table;integer;audit_table_name text, audit_schema_name text DEFAULT ''public''::text', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[63] = 'restore_change;anyelement;during_tid integer, aid bigint, column_name text, INOUT restored_value anyelement', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[64] = 'restore_query;text;start_from_tid integer, end_at_tid integer, table_name text, schema_name text DEFAULT ''public''::text, aid bigint DEFAULT NULL::bigint, all_versions boolean DEFAULT false', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[65] = 'restore_record;SETOF record;start_from_tid integer, end_at_tid integer, table_name text, schema_name text, aid bigint, jsonb_output boolean DEFAULT false', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[66] = 'restore_record_definition;text;tid integer, table_name text, schema_name text DEFAULT ''public''::text, audit_id_column_name text DEFAULT ''pgmemento_audit_id''::text', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[67] = 'restore_record_definition;text;start_from_tid integer, end_at_tid integer, table_log_id integer, audit_id_column_name text DEFAULT ''pgmemento_audit_id''::text', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[68] = 'restore_records;SETOF record;start_from_tid integer, end_at_tid integer, table_name text, schema_name text, aid bigint, jsonb_output boolean DEFAULT false', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[69] = 'restore_recordset;SETOF record;start_from_tid integer, end_at_tid integer, table_name text, schema_name text DEFAULT ''public''::text, jsonb_output boolean DEFAULT false', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[70] = 'restore_recordsets;SETOF record;start_from_tid integer, end_at_tid integer, table_name text, schema_name text DEFAULT ''public''::text, jsonb_output boolean DEFAULT false', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[71] = 'restore_schema_state;SETOF void;start_from_tid integer, end_at_tid integer, original_schema_name text, target_schema_name text, target_table_type text DEFAULT ''VIEW''::text, update_state boolean DEFAULT false', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[72] = 'restore_table_state;SETOF void;start_from_tid integer, end_at_tid integer, original_table_name text, original_schema_name text, target_schema_name text, target_table_type text DEFAULT ''VIEW''::text, update_state boolean DEFAULT false', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[73] = 'restore_value;anyelement;until_tid integer, aid bigint, column_name text, INOUT restored_value anyelement', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[74] = 'revert_distinct_transaction;SETOF void;tid integer', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[75] = 'revert_distinct_transactions;SETOF void;start_from_tid integer, end_at_tid integer', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[76] = 'revert_transaction;SETOF void;tid integer', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[77] = 'revert_transactions;SETOF void;start_from_tid integer, end_at_tid integer', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[78] = 'schema_drop_pre_trigger;event_trigger', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[79] = 'sequence_schema_state;SETOF void;target_schema_name text, original_schema_name text DEFAULT ''public''::text', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[80] = 'split_table_from_query;record;INOUT query text, OUT audit_table_name text, OUT audit_schema_name text, OUT audit_table_log_id integer, OUT audit_id_column_name text, OUT audit_old_data boolean', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[81] = 'start;text;schema_name text DEFAULT ''public''::text, audit_id_column_name text DEFAULT ''pgmemento_audit_id''::text, log_old_data boolean DEFAULT true, log_new_data boolean DEFAULT false, trigger_create_table boolean DEFAULT false, except_tables text[] DEFAULT ''{}''::text[]', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[82] = 'stop;text;schema_name text DEFAULT ''public''::text, except_tables text[] DEFAULT ''{}''::text[]', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[83] = 'table_alter_post_trigger;event_trigger', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[84] = 'table_alter_pre_trigger;event_trigger', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[85] = 'table_create_post_trigger;event_trigger', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[86] = 'table_drop_post_trigger;event_trigger', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[87] = 'table_drop_pre_trigger;event_trigger', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[88] = 'trim_outer_quotes;text;quoted_string text', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[89] = 'unregister_audit_table;SETOF void;audit_table_name text, audit_schema_name text DEFAULT ''public''::text', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[90] = 'update_key;SETOF bigint;aid bigint, path_to_key_name text[], old_value anyelement, new_value anyelement', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[91] = 'version;record;OUT full_version text, OUT major_version integer, OUT minor_version integer, OUT build_id text', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[16] = 'drop;text;schemaname text DEFAULT ''public''::text, keep_log boolean DEFAULT true, except_tables text[] DEFAULT ''{}''::text[]', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[17] = 'drop_schema_audit;SETOF void;schema_name text DEFAULT ''public''::text, keep_log boolean DEFAULT true, except_tables text[] DEFAULT ''{}''::text[]', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[18] = 'drop_schema_audit_id;SETOF void;schema_name text DEFAULT ''public''::text, except_tables text[] DEFAULT ''{}''::text[]', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[19] = 'drop_schema_event_trigger;SETOF void', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[20] = 'drop_schema_log_trigger;SETOF void;schema_name text DEFAULT ''public''::text, except_tables text[] DEFAULT ''{}''::text[]', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[21] = 'drop_schema_state;SETOF void;target_schema_name text, except_tables text[] DEFAULT ''{}''::text[]', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[22] = 'drop_table_audit;SETOF void;table_name text, schema_name text DEFAULT ''public''::text, audit_id_column_name text DEFAULT ''pgmemento_audit_id''::text, keep_log boolean DEFAULT true', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[23] = 'drop_table_audit_id;SETOF void;table_name text, schema_name text DEFAULT ''public''::text, audit_id_column_name text DEFAULT ''pgmemento_audit_id''::text', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[24] = 'drop_table_log_trigger;SETOF void;table_name text, schema_name text DEFAULT ''public''::text', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[25] = 'drop_table_state;SETOF void;table_name text, target_schema_name text DEFAULT ''public''::text', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[26] = 'fetch_ident;text;context text, fetch_count integer DEFAULT 1', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[27] = 'fkey_schema_state;SETOF void;target_schema_name text, original_schema_name text DEFAULT ''public''::text, except_tables text[] DEFAULT ''{}''::text[]', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[28] = 'fkey_table_state;SETOF void;table_name text, target_schema_name text, original_schema_name text DEFAULT ''public''::text', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[29] = 'flatten_ddl;text;ddl_command text', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[30] = 'get_column_list_by_txid;SETOF record;tid integer, table_name text, schema_name text DEFAULT ''public''::text, OUT column_name text, OUT data_type text, OUT ordinal_position integer', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[31] = 'get_column_list_by_txid_range;SETOF record;start_from_tid integer, end_at_tid integer, table_log_id integer, OUT column_name text, OUT column_count integer, OUT data_type text, OUT ordinal_position integer, OUT txid_range numrange', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[32] = 'get_ddl_from_context;text;stack text', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[33] = 'get_max_txid_to_audit_id;integer;aid bigint', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[34] = 'get_min_txid_to_audit_id;integer;aid bigint', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[35] = 'get_operation_id;smallint;operation text', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[36] = 'get_table_oid;oid;table_name text, schema_name text DEFAULT ''public''::text', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[37] = 'get_txid_bounds_to_table;record;table_log_id integer, OUT txid_min integer, OUT txid_max integer', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[38] = 'get_txids_to_audit_id;SETOF integer;aid bigint', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[39] = 'index_schema_state;SETOF void;target_schema_name text, original_schema_name text DEFAULT ''public''::text, except_tables text[] DEFAULT ''{}''::text[]', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[40] = 'index_table_state;SETOF void;table_name text, target_schema_name text, original_schema_name text DEFAULT ''public''::text', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[41] = 'init;text;schemaname text DEFAULT ''public''::text, audit_id_column_name text DEFAULT ''pgmemento_audit_id''::text, log_old_data boolean DEFAULT true, log_new_data boolean DEFAULT false, log_state boolean DEFAULT false, trigger_create_table boolean DEFAULT false, except_tables text[] DEFAULT ''{}''::text[]', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[42] = 'jsonb_merge;jsonb;jsonb', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[43] = 'jsonb_populate_value;anyelement;jsonb_log jsonb, column_name text, INOUT template anyelement', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[44] = 'jsonb_unroll_for_update;text;path text, nested_value jsonb, complex_typname text', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[45] = 'log_delete;trigger', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[46] = 'log_insert;trigger', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[47] = 'log_new_table_state;SETOF void;columns text[], tablename text, schemaname text, table_event_key text, audit_id_column_name text DEFAULT ''pgmemento_audit_id''::text', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[48] = 'log_old_table_state;SETOF void;columns text[], tablename text, schemaname text, table_event_key text, audit_id_column_name text DEFAULT ''pgmemento_audit_id''::text', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[49] = 'log_schema_baseline;SETOF void;audit_schema_name text DEFAULT ''public''::text', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[50] = 'log_statement;trigger', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[51] = 'log_table_baseline;SETOF void;table_name text, schema_name text DEFAULT ''public''::text, audit_id_column_name text DEFAULT ''pgmemento_audit_id''::text, log_new_data boolean DEFAULT false', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[52] = 'log_table_event;text;event_txid bigint, tablename text, schemaname text, op_type text', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[53] = 'log_transaction;integer;current_txid bigint', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[54] = 'log_truncate;trigger', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[55] = 'log_update;trigger', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[56] = 'modify_ddl_log_tables;SETOF void;tablename text, schemaname text', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[57] = 'modify_row_log;SETOF void;tablename text, schemaname text, audit_id_column_name text DEFAULT ''pgmemento_audit_id''::text', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[58] = 'move_schema_state;SETOF void;target_schema_name text, source_schema_name text DEFAULT ''public''::text, except_tables text[] DEFAULT ''{}''::text[], copy_data boolean DEFAULT true', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[59] = 'move_table_state;SETOF void;table_name text, target_schema_name text, source_schema_name text, copy_data boolean DEFAULT true', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[60] = 'pkey_schema_state;SETOF void;target_schema_name text, original_schema_name text DEFAULT ''public''::text, except_tables text[] DEFAULT ''{}''::text[]', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[61] = 'pkey_table_state;SETOF void;target_table_name text, target_schema_name text, original_schema_name text DEFAULT ''public''::text', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[62] = 'recover_audit_version;SETOF void;tid integer, aid bigint, changes jsonb, table_op integer, table_name text, schema_name text DEFAULT ''public''::text, audit_id_column_name text DEFAULT ''pgmemento_audit_id''::text', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[63] = 'register_audit_table;integer;audit_table_name text, audit_schema_name text DEFAULT ''public''::text', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[64] = 'restore_change;anyelement;during_tid integer, aid bigint, column_name text, INOUT restored_value anyelement', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[65] = 'restore_query;text;start_from_tid integer, end_at_tid integer, table_name text, schema_name text DEFAULT ''public''::text, aid bigint DEFAULT NULL::bigint, all_versions boolean DEFAULT false', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[66] = 'restore_record;SETOF record;start_from_tid integer, end_at_tid integer, table_name text, schema_name text, aid bigint, jsonb_output boolean DEFAULT false', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[67] = 'restore_record_definition;text;tid integer, table_name text, schema_name text DEFAULT ''public''::text, audit_id_column_name text DEFAULT ''pgmemento_audit_id''::text', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[68] = 'restore_record_definition;text;start_from_tid integer, end_at_tid integer, table_log_id integer, audit_id_column_name text DEFAULT ''pgmemento_audit_id''::text', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[69] = 'restore_records;SETOF record;start_from_tid integer, end_at_tid integer, table_name text, schema_name text, aid bigint, jsonb_output boolean DEFAULT false', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[70] = 'restore_recordset;SETOF record;start_from_tid integer, end_at_tid integer, table_name text, schema_name text DEFAULT ''public''::text, jsonb_output boolean DEFAULT false', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[71] = 'restore_recordsets;SETOF record;start_from_tid integer, end_at_tid integer, table_name text, schema_name text DEFAULT ''public''::text, jsonb_output boolean DEFAULT false', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[72] = 'restore_schema_state;SETOF void;start_from_tid integer, end_at_tid integer, original_schema_name text, target_schema_name text, target_table_type text DEFAULT ''VIEW''::text, update_state boolean DEFAULT false', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[73] = 'restore_table_state;SETOF void;start_from_tid integer, end_at_tid integer, original_table_name text, original_schema_name text, target_schema_name text, target_table_type text DEFAULT ''VIEW''::text, update_state boolean DEFAULT false', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[74] = 'restore_value;anyelement;until_tid integer, aid bigint, column_name text, INOUT restored_value anyelement', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[75] = 'revert_distinct_transaction;SETOF void;tid integer', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[76] = 'revert_distinct_transactions;SETOF void;start_from_tid integer, end_at_tid integer', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[77] = 'revert_transaction;SETOF void;tid integer', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[78] = 'revert_transactions;SETOF void;start_from_tid integer, end_at_tid integer', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[79] = 'schema_drop_pre_trigger;event_trigger', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[80] = 'sequence_schema_state;SETOF void;target_schema_name text, original_schema_name text DEFAULT ''public''::text', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[81] = 'split_table_from_query;record;INOUT query text, OUT audit_table_name text, OUT audit_schema_name text, OUT audit_table_log_id integer, OUT audit_id_column_name text, OUT audit_old_data boolean', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[82] = 'start;text;schemaname text DEFAULT ''public''::text, audit_id_column_name text DEFAULT ''pgmemento_audit_id''::text, log_old_data boolean DEFAULT true, log_new_data boolean DEFAULT false, trigger_create_table boolean DEFAULT false, except_tables text[] DEFAULT ''{}''::text[]', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[83] = 'stop;text;schemaname text DEFAULT ''public''::text, except_tables text[] DEFAULT ''{}''::text[]', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[84] = 'table_alter_post_trigger;event_trigger', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[85] = 'table_alter_pre_trigger;event_trigger', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[86] = 'table_create_post_trigger;event_trigger', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[87] = 'table_drop_post_trigger;event_trigger', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[88] = 'table_drop_pre_trigger;event_trigger', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[89] = 'trim_outer_quotes;text;quoted_string text', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[90] = 'unregister_audit_table;SETOF void;audit_table_name text, audit_schema_name text DEFAULT ''public''::text', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[91] = 'update_key;SETOF bigint;aid bigint, path_to_key_name text[], old_value anyelement, new_value anyelement', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[92] = 'version;record;OUT full_version text, OUT major_version integer, OUT minor_version integer, OUT build_id text', 'Error: Expected different function and/or arguments';
 END;
 $$
 LANGUAGE plpgsql;

--- a/test/setup/TEST_STOP_START.sql
+++ b/test/setup/TEST_STOP_START.sql
@@ -1,0 +1,142 @@
+-- TEST_STOP_START.sql
+--
+-- Author:      Felix Kunde <felix-kunde@gmx.de>
+--
+--              This script is free software under the LGPL Version 3
+--              See the GNU Lesser General Public License at
+--              http://www.gnu.org/copyleft/lgpl.html
+--              for more details.
+-------------------------------------------------------------------------------
+-- About:
+-- Script that stops and starts auditing for given schema
+-------------------------------------------------------------------------------
+--
+-- ChangeLog:
+--
+-- Version | Date       | Description                                  | Author
+-- 0.1.0     2020-04-12   initial commit                                 FKun
+--
+
+-- get test number
+SELECT nextval('pgmemento.test_seq') AS n \gset
+
+\echo
+\echo 'TEST ':n': pgMemento ctl functions stop and start'
+
+\echo
+\echo 'TEST ':n'.1: Stop pgMemento in public schema'
+DO
+$$
+DECLARE
+  tab_schema TEXT := 'public';
+  tab TEXT := 'object';
+BEGIN
+  -- stop logging in public schema
+  -- should drop log triggers
+  PERFORM pgmemento.stop(tab_schema);
+
+  -- query for logged transaction
+  ASSERT (
+    SELECT EXISTS (
+      SELECT session_info ? 'pgmemento_stop'
+        FROM pgmemento.transaction_log
+       WHERE id = current_setting('pgmemento.' || txid_current())::numeric
+    )
+  ), 'Error: Could not find entry in transaction_log for stopping audit trail in schema %!', tab_schema;
+
+  -- query for log trigger
+  ASSERT (
+    SELECT NOT EXISTS (
+      SELECT
+        1
+      FROM (
+        VALUES
+          ('pgmemento_delete_trigger'),
+          ('pgmemento_insert_trigger'),
+          ('pgmemento_transaction_trigger'),
+          ('pgmemento_truncate_trigger'),
+          ('pgmemento_update_trigger')
+        ) AS p (pgm_trigger)
+      JOIN (
+        SELECT
+          tg.tgname
+        FROM
+          pg_trigger tg,
+          pg_class c
+        WHERE
+          tg.tgrelid = c.oid
+          AND c.relname = tab
+        ) t
+        ON t.tgname = p.pgm_trigger
+    )
+  ), 'Error: Some log trigger still exist for % table. Drop function did not work properly!', tab;
+END;
+$$
+LANGUAGE plpgsql;
+
+
+\echo
+\echo 'TEST ':n'.2: Restart pgMemento in public schema'
+DO
+$$
+DECLARE
+  tab_schema TEXT := 'public';
+  tab TEXT := 'object';
+BEGIN
+  -- restart logging in public schema
+  -- but with default logging behavior which is different
+  PERFORM pgmemento.start(tab_schema);
+
+  -- query for log trigger
+  ASSERT (
+    SELECT NOT EXISTS (
+      SELECT
+        1
+      FROM (
+        VALUES
+          ('pgmemento_delete_trigger'),
+          ('pgmemento_insert_trigger'),
+          ('pgmemento_transaction_trigger'),
+          ('pgmemento_truncate_trigger'),
+          ('pgmemento_update_trigger')
+        ) AS p (pgm_trigger)
+      LEFT JOIN (
+        SELECT
+          tg.tgname
+        FROM
+          pg_trigger tg,
+          pg_class c
+        WHERE
+          tg.tgrelid = c.oid
+          AND c.relname = tab
+        ) t
+        ON t.tgname = p.pgm_trigger
+      WHERE
+        t.tgname IS NULL
+    )
+  ), 'Error: Did not find all necessary trigger for % table!', tab;
+
+  -- query for logged transaction
+  ASSERT (
+    SELECT EXISTS (
+      SELECT session_info ? 'pgmemento_start'
+        FROM pgmemento.transaction_log
+       WHERE id = current_setting('pgmemento.' || txid_current())::numeric
+    )
+  ), 'Error: Could not find entry in transaction_log for stopping audit trail in schema %!', tab_schema;
+
+  -- test if new entry was made in audit_schema_log table
+  ASSERT (
+    SELECT EXISTS(
+      SELECT
+        1
+      FROM
+        pgmemento.audit_schema_log
+      WHERE
+        schema_name = tab_schema
+        AND lower(txid_range) = current_setting('pgmemento.' || txid_current())::numeric
+    )
+  ), 'Error: Did not find entry for % schema in audit_schema_log!', tab_schema;
+END;
+$$
+LANGUAGE plpgsql;


### PR DESCRIPTION
- calling `create_table_audit` should check if schema is already audited
- dropping pgMemento from schema should update `audit_schema_log`
- `drop_schema_...` functions should call CTL functions, too