### PR TITLE
fix null check in restore_record

### DIFF
--- a/INIT.sql
+++ b/INIT.sql
@@ -34,7 +34,7 @@ SET client_min_messages TO WARNING;
 \echo 'Initializing pgMemento in ':schema_name' schema ...'
 
 SELECT pgmemento.init(
-  :'schema_name'
+  :'schema_name',
   'pgmemento_audit_id',
   TRUE,
   CASE WHEN lower(:'log_new_data') = 'y' OR lower(:'log_new_data') = 'yes' THEN TRUE ELSE FALSE END,

--- a/UNINSTALL_PGMEMENTO.sql
+++ b/UNINSTALL_PGMEMENTO.sql
@@ -14,6 +14,7 @@
 -- ChangeLog:
 --
 -- Version | Date       | Description                                    | Author
+-- 0.4.0     2020-04-13   reflect configurable audit_id column             FKun
 -- 0.3.0     2020-03-23   use audit_tables view to delete pgMemento        FKun
 -- 0.2.0     2017-07-26   reflect changes of later pgMemento versions      FKun
 -- 0.1.0     2015-06-20   initial commit                                   FKun
@@ -33,6 +34,7 @@ SELECT
   pgmemento.drop_table_audit(
     tablename,
     schemaname,
+    audit_id_column,
     FALSE
   )
 FROM

--- a/UPGRADE_v061_to_v07.sql
+++ b/UPGRADE_v061_to_v07.sql
@@ -137,7 +137,7 @@ DROP FUNCTION IF EXISTS pgmemento.pkey_table_state(table_name TEXT, target_schem
 
 DROP FUNCTION IF EXISTS pgmemento.restore_record_definition(start_from_tid INTEGER, end_at_tid INTEGER, table_oid OID);
 
-DROP FUNCTION IF EXISTS pgmemento.restore_record_definition(start_from_tid INTEGER, end_at_tid INTEGER, table_oid OID);
+DROP FUNCTION IF EXISTS pgmemento.restore_record_definition(tid INTEGER, table_name TEXT, schema_name TEXT);
 
 DROP FUNCTION IF EXISTS pgmemento.recover_audit_version(tid INTEGER, aid BIGINT, changes JSONB, table_op INTEGER, table_name TEXT, schema_name TEXT);
 

--- a/UPGRADE_v061_to_v07.sql
+++ b/UPGRADE_v061_to_v07.sql
@@ -167,6 +167,8 @@ DROP FUNCTION IF EXISTS pgmemento.drop_schema_audit(schema_name TEXT, keep_log B
 
 DROP FUNCTION IF EXISTS pgmemento.drop_table_audit(table_name TEXT, schema_name TEXT, keep_log BOOLEAN);
 
+DROP FUNCTION IF EXISTS pgmemento.drop_table_audit_id(table_name TEXT, schema_name TEXT);
+
 DROP AGGREGATE IF EXISTS pgmemento.jsonb_merge(jsonb);
 
 \echo

--- a/ctl/START.sql
+++ b/ctl/START.sql
@@ -23,7 +23,7 @@
 \echo 'Starting pgMemento for tables in ':schema_name' schema ...'
 
 SELECT pgmemento.start(
-  :'schema_name'
+  :'schema_name',
   'pgmemento_audit_id',
   TRUE,
   CASE WHEN lower(:'log_new_data') = 'y' OR lower(:'log_new_data') = 'yes' THEN TRUE ELSE FALSE END,

--- a/src/CTL.sql
+++ b/src/CTL.sql
@@ -305,6 +305,6 @@ CREATE OR REPLACE FUNCTION pgmemento.version(
   OUT build_id TEXT
   ) RETURNS RECORD AS
 $$
-SELECT 'pgMemento 0.7'::text AS full_version, 0 AS major_version, 7 AS minor_version, '49'::text AS build_id;
+SELECT 'pgMemento 0.7'::text AS full_version, 0 AS major_version, 7 AS minor_version, '50'::text AS build_id;
 $$
 LANGUAGE sql;

--- a/src/CTL.sql
+++ b/src/CTL.sql
@@ -305,6 +305,6 @@ CREATE OR REPLACE FUNCTION pgmemento.version(
   OUT build_id TEXT
   ) RETURNS RECORD AS
 $$
-SELECT 'pgMemento 0.7'::text AS full_version, 0 AS major_version, 7 AS minor_version, '50'::text AS build_id;
+SELECT 'pgMemento 0.7'::text AS full_version, 0 AS major_version, 7 AS minor_version, '51'::text AS build_id;
 $$
 LANGUAGE sql;

--- a/src/CTL.sql
+++ b/src/CTL.sql
@@ -72,7 +72,7 @@ BEGIN
   -- start auditing for tables in given schema'
   PERFORM pgmemento.create_schema_audit(quote_ident($1), $2, $3, $4, $5, $6, $7);
 
-  RETURN format('pgMemento is initialized on %s schema.', $1);
+  RETURN format('pgMemento is initialized for %s schema.', $1);
 END;
 $$
 LANGUAGE plpgsql;
@@ -104,7 +104,7 @@ BEGIN
   LIMIT 1;
 
   IF current_audit_schema_log.id IS NULL THEN
-    RETURN format('pgMemento is not yet intialized on %s schema. Run init first.', $1);
+    RETURN format('pgMemento is not yet intialized for %s schema. Run init first.', $1);
   END IF;
 
   -- log transaction that starts pgMemento for a schema
@@ -127,7 +127,7 @@ BEGIN
          SET txid_range = numrange(lower(txid_range), txid_log_id::numeric, '(]')
        WHERE id = current_audit_schema_log.id;
     ELSE
-      RETURN format('pgMemento is already started on %s schema.', $1);
+      RETURN format('pgMemento is already started for %s schema.', $1);
     END IF;
   END IF;
 
@@ -160,7 +160,7 @@ BEGIN
     PERFORM pgmemento.create_schema_event_trigger($5);
   END IF;
 
-  RETURN format('pgMemento is started on %s schema.', $1);
+  RETURN format('pgMemento is started for %s schema.', $1);
 END;
 $$
 LANGUAGE plpgsql;
@@ -190,11 +190,11 @@ BEGIN
   LIMIT 1;
 
   IF current_schema_log_id IS NULL THEN
-    RETURN format('pgMemento is not intialized on %s schema.', $1);
+    RETURN format('pgMemento is not intialized for %s schema.', $1);
   END IF;
 
   IF upper(current_schema_log_range) IS NOT NULL THEN
-    RETURN format('pgMemento is already stopped on %s schema.', $1);
+    RETURN format('pgMemento is already stopped for %s schema.', $1);
   END IF;
 
   -- log transaction that stops pgMemento for a schema
@@ -220,11 +220,11 @@ BEGIN
          AND at.schemaname = $1
        WHERE tg_is_active
     ) THEN
-      RETURN format('pgMemento is partly stopped on %s schema.', $1);
+      RETURN format('pgMemento is partly stopped for %s schema.', $1);
     END IF;
   END IF;
 
-  RETURN format('pgMemento is stopped on %s schema.', $1);
+  RETURN format('pgMemento is stopped for %s schema.', $1);
 END;
 $$
 LANGUAGE plpgsql;
@@ -256,7 +256,7 @@ BEGIN
   LIMIT 1;
 
   IF current_schema_log_id IS NULL THEN
-    RETURN format('pgMemento is not intialized on %s schema.', $1);
+    RETURN format('pgMemento is not intialized for %s schema.', $1);
   END IF;
 
   -- log transaction that drops pgMemento from a schema

--- a/src/REVERT.sql
+++ b/src/REVERT.sql
@@ -16,6 +16,7 @@
 -- ChangeLog:
 --
 -- Version | Date       | Description                                   | Author
+-- 0.7.4     2020-04-13   reflect configurable audit_id column            FKun
 -- 0.7.3     2020-02-29   reflect new schema of row_log table             FKun
 -- 0.7.2     2020-01-09   reflect changes on schema and triggers          FKun
 -- 0.7.1     2019-04-21   reuse log_id when reverting DROP TABLE events   FKun
@@ -145,8 +146,7 @@ BEGIN
 
   -- ADD AUDIT_ID case
   WHEN $4 = 21 THEN
-    PERFORM pgmemento.drop_table_audit($5, $6, $7);
-
+    PERFORM pgmemento.drop_table_audit($5, $6, $7, TRUE);
 
   -- RENAME COLUMN case
   WHEN $4 = 22 THEN


### PR DESCRIPTION
- NOT NULL check on rowtype is true only if all columns are NOT NULL
- use RETURN QUERY instead, because function has changed to RETURN SETOF RECORD for `v0.6.1` anyway
- keep log when reverting ADD_AUDIT
- more bugfixes in setup scripts functions