### PR TITLE
remove txid arg from log_table_event

### DIFF
--- a/src/CTL.sql
+++ b/src/CTL.sql
@@ -305,6 +305,6 @@ CREATE OR REPLACE FUNCTION pgmemento.version(
   OUT build_id TEXT
   ) RETURNS RECORD AS
 $$
-SELECT 'pgMemento 0.7'::text AS full_version, 0 AS major_version, 7 AS minor_version, '51'::text AS build_id;
+SELECT 'pgMemento 0.7'::text AS full_version, 0 AS major_version, 7 AS minor_version, '52'::text AS build_id;
 $$
 LANGUAGE sql;

--- a/src/REVERT.sql
+++ b/src/REVERT.sql
@@ -418,7 +418,7 @@ BEGIN
 
     -- try to create table
     IF stmt IS NOT NULL THEN
-      PERFORM pgmemento.log_table_event(txid_current(), $5, $6, 'RECREATE TABLE');
+      PERFORM pgmemento.log_table_event($5, $6, 'RECREATE TABLE');
       PERFORM set_config('pgmemento.' || $6 || '.' || $5, table_log_id::text, TRUE);
       EXECUTE format('CREATE TABLE IF NOT EXISTS %I.%I (' || stmt || ')', $6, $5);
     END IF;

--- a/test/setup/TEST_INSTALL.sql
+++ b/test/setup/TEST_INSTALL.sql
@@ -156,7 +156,7 @@ BEGIN
   ASSERT pgm_objects[49] = 'log_schema_baseline;SETOF void;audit_schema_name text DEFAULT ''public''::text', 'Error: Expected different function and/or arguments';
   ASSERT pgm_objects[50] = 'log_statement;trigger', 'Error: Expected different function and/or arguments';
   ASSERT pgm_objects[51] = 'log_table_baseline;SETOF void;table_name text, schema_name text DEFAULT ''public''::text, audit_id_column_name text DEFAULT ''pgmemento_audit_id''::text, log_new_data boolean DEFAULT false', 'Error: Expected different function and/or arguments';
-  ASSERT pgm_objects[52] = 'log_table_event;text;event_txid bigint, tablename text, schemaname text, op_type text', 'Error: Expected different function and/or arguments';
+  ASSERT pgm_objects[52] = 'log_table_event;text;tablename text, schemaname text, op_type text', 'Error: Expected different function and/or arguments';
   ASSERT pgm_objects[53] = 'log_transaction;integer;current_txid bigint', 'Error: Expected different function and/or arguments';
   ASSERT pgm_objects[54] = 'log_truncate;trigger', 'Error: Expected different function and/or arguments';
   ASSERT pgm_objects[55] = 'log_update;trigger', 'Error: Expected different function and/or arguments';


### PR DESCRIPTION
Call txid_current() only within `log_table_event`.
In fact, it could also be called within `log_transaction` but this makes upgrade path harder :)