### PR TITLE
make upgrade process less intense

### DIFF
--- a/ctl/UPGRADE.sql
+++ b/ctl/UPGRADE.sql
@@ -14,6 +14,7 @@
 -- ChangeLog:
 --
 -- Version | Date       | Description                                    | Author
+-- 0.2.5     2020-04-25   copy log tables instead of updating them         FKun
 -- 0.2.4     2020-04-20   update op_id of DROP AUDIT_ID events             FKun
 -- 0.2.3     2020-03-30   create and fill new audit_schema_log table       FKun
 -- 0.2.2     2020-02-29   reflect new schema of row_log table              FKun
@@ -23,106 +24,96 @@
 -- 0.1.0     2018-07-23   initial commit                                   FKun
 --
 
--- TRANSACTION_LOG
--- rename stmt_date column
-ALTER TABLE pgmemento.transaction_log
-  RENAME stmt_date TO txid_time;
-
-COMMENT ON COLUMN pgmemento.transaction_log.txid_time IS 'Stores the result of transaction_timestamp() function';
-
+\echo
+\echo 'TRANSACTION_LOG: Create new unique index'
 -- reverse unqiue index which makes other time index obsolete
-CREATE UNIQUE INDEX IF NOT EXISTS transaction_log_unique_idx2 ON pgmemento.transaction_log USING BTREE (txid_time, txid);
+CREATE UNIQUE INDEX IF NOT EXISTS transaction_log_unique_idx_2 ON pgmemento.transaction_log USING BTREE (stmt_date, txid);
 DROP INDEX IF EXISTS transaction_log_unique_idx;
-ALTER INDEX IF EXISTS transaction_log_unique_idx2 RENAME TO transaction_log_unique_idx;
+ALTER INDEX IF EXISTS transaction_log_unique_idx_2 RENAME TO transaction_log_unique_idx;
 DROP INDEX IF EXISTS transaction_log_date_idx;
 
--- TABLE_EVENT_LOG
--- replace table_relid with columns table_name and schema_name
-ALTER TABLE pgmemento.table_event_log
-  ALTER COLUMN table_operation TYPE TEXT,
-  ADD COLUMN stmt_time TIMESTAMP WITH TIME ZONE,
-  ADD COLUMN table_name TEXT,
-  ADD COLUMN schema_name TEXT,
-  ADD COLUMN event_key TEXT;
+-- get current sequence values for copying
+SELECT nextval('pgmemento.table_event_log_id_seq') AS curr_seq_event_log \gset
+SELECT nextval('pgmemento.row_log_id_seq') AS curr_seq_row_log \gset
 
-COMMENT ON COLUMN pgmemento.table_event_log.stmt_time IS 'Stores the result of statement_timestamp() function';
-COMMENT ON COLUMN pgmemento.table_event_log.table_name IS 'Name of table that fired the trigger';
-COMMENT ON COLUMN pgmemento.table_event_log.schema_name IS 'Schema of firing table';
-COMMENT ON COLUMN pgmemento.table_event_log.event_key IS 'Concatenated information of most columns';
-
--- fill new columns with values
-UPDATE pgmemento.table_event_log e
-   SET stmt_time = t.txid_time,
-       event_key = concat_ws(';', extract(epoch from t.txid_time), extract(epoch from t.txid_time), t.txid, e.op_id)
-  FROM pgmemento.transaction_log t
- WHERE e.transaction_id = t.id;
-
-UPDATE pgmemento.table_event_log e
-   SET table_name = atl.table_name,
-       schema_name = atl.schema_name,
-       event_key = concat_ws(';', e.event_key, atl.table_name, atl.schema_name)
-  FROM pgmemento.audit_table_log atl
- WHERE atl.relid = e.table_relid
+\echo
+\echo 'TABLE_EVENT_LOG: Create copy with new columns'
+CREATE TABLE IF NOT EXISTS pgmemento.table_event_log_2 AS
+  SELECT
+    e.id,
+    e.transaction_id,
+    t.stmt_date AS stmt_time,
+    CASE WHEN e.table_operation = 'DROP AUDIT_ID' THEN 81::smallint ELSE e.op_id END AS op_id,
+    table_operation,
+    atl.table_name,
+    atl.schema_name,
+    concat_ws(';', extract(epoch from t.stmt_date), extract(epoch from t.stmt_date), t.txid, e.op_id, atl.table_name, atl.schema_name) AS event_key
+  FROM
+    pgmemento.table_event_log e
+  JOIN
+    pgmemento.transaction_log t
+    ON t.id = e.transaction_id
+  JOIN pgmemento.audit_table_log atl
+    ON atl.relid = e.table_relid
    AND (atl.txid_range @> e.transaction_id::numeric
-    OR lower(atl.txid_range) = e.transaction_id::numeric);
+    OR (lower(atl.txid_range) = e.transaction_id::numeric AND NOT e.op_id = 12))
+  WHERE e.id < :curr_seq_event_log;
 
-UPDATE pgmemento.table_event_log
-   SET op_id = 81
- WHERE table_operation = 'DROP AUDIT_ID';
-
--- set columns to NOT NULL and update indexes
-ALTER TABLE pgmemento.table_event_log
-  DROP COLUMN table_relid,
+-- set constraints
+ALTER TABLE pgmemento.table_event_log_2
+  ADD CONSTRAINT table_event_log_2_pk PRIMARY KEY (id),
+  ADD CONSTRAINT table_event_log_txid_2_fk FOREIGN KEY (transaction_id)
+    REFERENCES pgmemento.transaction_log (id) MATCH FULL
+    ON DELETE CASCADE ON UPDATE CASCADE,
+  ALTER COLUMN transaction_id SET NOT NULL,
   ALTER COLUMN stmt_time SET NOT NULL,
+  ALTER COLUMN op_id SET NOT NULL,
+  ALTER COLUMN table_operation SET NOT NULL,
   ALTER COLUMN table_name SET NOT NULL,
   ALTER COLUMN schema_name SET NOT NULL,
   ALTER COLUMN event_key SET NOT NULL;
 
-CREATE INDEX IF NOT EXISTS table_event_log_fk_idx ON pgmemento.table_event_log USING BTREE (transaction_id);
-CREATE UNIQUE INDEX IF NOT EXISTS table_event_log_event_idx ON pgmemento.table_event_log USING BTREE (event_key);
-DROP INDEX IF EXISTS table_event_log_unique_idx;
+-- created indexes
+CREATE INDEX IF NOT EXISTS table_event_log_fk_idx ON pgmemento.table_event_log_2 USING BTREE (transaction_id);
+CREATE UNIQUE INDEX IF NOT EXISTS table_event_log_event_idx ON pgmemento.table_event_log_2 USING BTREE (event_key);
 
 -- update table statistics
-VACUUM ANALYZE pgmemento.table_event_log;
+VACUUM ANALYZE pgmemento.table_event_log_2;
 
--- ROW_LOG
--- rename changes column to old_data because we can now have a new_data, too
--- remove foreign key but add event_key to link to table_event_log
-ALTER TABLE pgmemento.row_log
-  RENAME changes TO old_data;
+\echo
+\echo 'ROW_LOG: Create copy with new columns'
+CREATE TABLE IF NOT EXISTS pgmemento.row_log_2 AS
+  SELECT
+    r.id,
+    r.audit_id,
+    e.event_key,
+    r.changes AS old_data,
+    NULL::jsonb AS new_data
+  FROM
+    pgmemento.row_log r
+  JOIN
+    pgmemento.table_event_log_2 e
+    ON e.id = r.event_id
+  WHERE
+    r.id < :curr_seq_row_log;
 
-ALTER TABLE pgmemento.row_log
-  DROP CONSTRAINT row_log_table_fk,
-  ALTER COLUMN event_id DROP NOT NULL,
-  ADD COLUMN event_key TEXT,
-  ADD COLUMN new_data JSONB;
-
-COMMENT ON COLUMN pgmemento.row_log.event_key IS 'Concatenated information of table event';
-COMMENT ON COLUMN pgmemento.row_log.old_data IS 'The old values of changed columns in a JSONB object';
-COMMENT ON COLUMN pgmemento.row_log.new_data IS 'The new values of changed columns in a JSONB object';
-
--- fill new columns with values
-UPDATE pgmemento.row_log r
-   SET event_key = e.event_key
-  FROM pgmemento.table_event_log e
- WHERE r.event_id = e.id;
-
--- create new index on event_key and remove former foreign key index
-CREATE UNIQUE INDEX IF NOT EXISTS row_log_event_audit_idx ON pgmemento.row_log USING BTREE (event_key, audit_id);
-DROP INDEX IF EXISTS row_log_event_idx;
-
-ALTER TABLE pgmemento.row_log
-  DROP COLUMN event_id,
+-- set constraints
+ALTER TABLE pgmemento.row_log_2
+  ADD CONSTRAINT row_log_2_pk PRIMARY KEY (id),
+  ALTER COLUMN audit_id SET NOT NULL,
   ALTER COLUMN event_key SET NOT NULL;
 
--- rename index on previous changes column and create GIN index on new_data
-ALTER INDEX IF EXISTS row_log_changes_idx RENAME TO row_log_old_data_idx;
-CREATE INDEX IF NOT EXISTS row_log_new_data_idx ON pgmemento.row_log USING GIN (new_data);
+-- create index
+CREATE INDEX IF NOT EXISTS row_log_2_audit_idx ON pgmemento.row_log_2 USING BTREE (audit_id);
+CREATE UNIQUE INDEX IF NOT EXISTS row_log_event_audit_idx ON pgmemento.row_log_2 USING BTREE (event_key, audit_id);
+CREATE INDEX IF NOT EXISTS row_log_old_data_idx ON pgmemento.row_log_2 USING GIN (old_data);
+CREATE INDEX IF NOT EXISTS row_log_new_data_idx ON pgmemento.row_log_2 USING GIN (new_data);
 
 -- update table statistics
 VACUUM ANALYZE pgmemento.row_log;
 
--- AUDIT_TABLE_LOG
+\echo
+\echo 'AUDIT_TABLE_LOG: Adding new columns'
 -- introduce new column log_id with sequence
 DROP SEQUENCE IF EXISTS pgmemento.table_log_id_seq;
 CREATE SEQUENCE pgmemento.table_log_id_seq
@@ -175,8 +166,8 @@ CREATE INDEX IF NOT EXISTS table_log_idx ON pgmemento.audit_table_log USING BTRE
 -- update table statistics
 VACUUM ANALYZE pgmemento.audit_table_log;
 
--- AUDIT_SCHEMA_LOG
--- new table to log pgMemento's configuration per schema
+\echo
+\echo 'AUDIT_SCHEMA_LOG: New log table'
 CREATE TABLE pgmemento.audit_schema_log (
   id SERIAL,
   log_id INTEGER NOT NULL,
@@ -201,7 +192,6 @@ COMMENT ON COLUMN pgmemento.audit_schema_log.default_log_new_data IS 'Default se
 COMMENT ON COLUMN pgmemento.audit_schema_log.trigger_create_table IS 'Flag that shows if pgMemento starts auditing for newly created tables';
 COMMENT ON COLUMN pgmemento.audit_schema_log.txid_range IS 'Stores the transaction IDs when pgMemento has been activated or stopped in the schema';
 
-
 DROP SEQUENCE IF EXISTS pgmemento.schema_log_id_seq;
 CREATE SEQUENCE pgmemento.schema_log_id_seq
   INCREMENT BY 1
@@ -211,3 +201,138 @@ CREATE SEQUENCE pgmemento.schema_log_id_seq
   CACHE 1
   NO CYCLE
   OWNED BY NONE;
+
+\echo
+\echo 'Drop log triggers'
+DO
+$$
+DECLARE
+  rec RECORD;
+  remove_all_tx_tg BOOLEAN := TRUE; 
+BEGIN
+  FOR rec IN
+    SELECT schemaname, tablename
+      FROM pgmemento.audit_tables_copy
+     ORDER BY schemaname, tablename
+  LOOP
+    -- the first iteration will remove all log_transaction_triggers
+    IF remove_all_tx_tg THEN
+      DROP FUNCTION IF EXISTS pgmemento.log_transaction() CASCADE;
+      remove_all_tx_tg := FALSE;
+    END IF;
+
+    EXECUTE format('DROP TRIGGER IF EXISTS log_delete_trigger ON %I.%I', rec.schemaname, rec.tablename);
+    EXECUTE format('DROP TRIGGER IF EXISTS log_update_trigger ON %I.%I', rec.schemaname, rec.tablename);
+    EXECUTE format('DROP TRIGGER IF EXISTS log_insert_trigger ON %I.%I', rec.schemaname, rec.tablename);
+    EXECUTE format('DROP TRIGGER IF EXISTS log_truncate_trigger ON %I.%I', rec.schemaname, rec.tablename);
+  END LOOP;
+END;
+$$
+LANGUAGE plpgsql;
+
+\echo
+\echo 'TABLE_EVENT_LOG & ROW_LOG: Swap rows created after copying'
+INSERT INTO pgmemento.table_event_log_2
+  SELECT
+    e.id,
+    e.transaction_id,
+    t.stmt_date AS stmt_time,
+    CASE WHEN e.table_operation = 'DROP AUDIT_ID' THEN 81::smallint ELSE e.op_id END AS op_id,
+    table_operation,
+    atl.table_name,
+    atl.schema_name,
+    concat_ws(';', extract(epoch from t.stmt_date), extract(epoch from t.stmt_date), t.txid, e.op_id, atl.table_name, atl.schema_name)
+  FROM
+    pgmemento.table_event_log e
+  JOIN
+    pgmemento.transaction_log t
+    ON t.id = e.transaction_id
+  JOIN pgmemento.audit_table_log atl
+    ON atl.relid = e.table_relid
+   AND (atl.txid_range @> e.transaction_id::numeric
+    OR lower(atl.txid_range) = e.transaction_id::numeric)
+  WHERE
+    e.id >= :curr_seq_event_log;
+
+INSERT INTO pgmemento.row_log_2
+  SELECT
+    r.id,
+    r.audit_id,
+    e.event_key,
+    r.changes AS old_data,
+    NULL::jsonb AS new_data
+  FROM
+    pgmemento.row_log r
+  JOIN
+    pgmemento.table_event_log_2 e
+    ON e.id = r.event_id
+  WHERE
+    r.id >= :curr_seq_row_log;
+
+\echo
+\echo 'TABLE_EVENT_LOG & ROW_LOG: Drop original tables and rename copies'
+SELECT nextval('pgmemento.row_log_id_seq') AS curr_seq_row_log \gset
+
+DROP TABLE pgmemento.row_log;
+ALTER TABLE pgmemento.row_log_2 RENAME TO row_log;
+ALTER TABLE pgmemento.row_log RENAME CONSTRAINT row_log_2_pk TO row_log_pk;
+ALTER INDEX IF EXISTS row_log_2_audit_idx RENAME TO row_log_audit_idx;
+
+SELECT nextval('pgmemento.table_event_log_id_seq') AS curr_seq_event_log \gset
+
+DROP TABLE pgmemento.table_event_log;
+ALTER TABLE pgmemento.table_event_log_2 RENAME TO table_event_log;
+ALTER TABLE pgmemento.table_event_log RENAME CONSTRAINT table_event_log_2_pk TO table_event_log_pk;
+ALTER TABLE pgmemento.table_event_log RENAME CONSTRAINT table_event_log_txid_2_fk TO table_event_log_txid_fk;
+
+-- recreate sequences
+DROP SEQUENCE IF EXISTS pgmemento.row_log_id_seq;
+CREATE SEQUENCE pgmemento.row_log_id_seq
+  INCREMENT BY 1
+  MINVALUE 0
+  MAXVALUE 2147483647
+  START WITH :curr_seq_row_log
+  CACHE 1
+  NO CYCLE
+  OWNED BY NONE;
+
+ALTER TABLE pgmemento.row_log
+  ALTER COLUMN id SET DEFAULT nextval('pgmemento.row_log_id_seq');
+
+DROP SEQUENCE IF EXISTS pgmemento.table_event_log_id_seq;
+CREATE SEQUENCE pgmemento.table_event_log_id_seq
+  INCREMENT BY 1
+  MINVALUE 0
+  MAXVALUE 2147483647
+  START WITH :curr_seq_event_log
+  CACHE 1
+  NO CYCLE
+  OWNED BY NONE;
+
+ALTER TABLE pgmemento.table_event_log
+  ALTER COLUMN id SET DEFAULT nextval('pgmemento.table_event_log_id_seq');
+
+-- add comments
+COMMENT ON TABLE pgmemento.table_event_log IS 'Stores metadata about different kind of events happening during one transaction against one table';
+COMMENT ON COLUMN pgmemento.table_event_log.id IS 'The Primary Key';
+COMMENT ON COLUMN pgmemento.table_event_log.transaction_id IS 'Foreign Key to transaction_log table';
+COMMENT ON COLUMN pgmemento.table_event_log.stmt_time IS 'Stores the result of statement_timestamp() function';
+COMMENT ON COLUMN pgmemento.table_event_log.op_id IS 'ID of event type';
+COMMENT ON COLUMN pgmemento.table_event_log.table_operation IS 'Text for of event type';
+COMMENT ON COLUMN pgmemento.table_event_log.table_name IS 'Name of table that fired the trigger';
+COMMENT ON COLUMN pgmemento.table_event_log.schema_name IS 'Schema of firing table';
+COMMENT ON COLUMN pgmemento.table_event_log.event_key IS 'Concatenated information of most columns';
+
+COMMENT ON TABLE pgmemento.row_log IS 'Stores the historic data a.k.a the audit trail';
+COMMENT ON COLUMN pgmemento.row_log.id IS 'The Primary Key';
+COMMENT ON COLUMN pgmemento.row_log.audit_id IS ' The implicit link to a table''s row';
+COMMENT ON COLUMN pgmemento.row_log.event_key IS 'Concatenated information of table event';
+COMMENT ON COLUMN pgmemento.row_log.old_data IS 'The old values of changed columns in a JSONB object';
+COMMENT ON COLUMN pgmemento.row_log.new_data IS 'The new values of changed columns in a JSONB object';
+
+\echo
+\echo 'TRANSACTION_LOG: Rename stmt_date column'
+ALTER TABLE pgmemento.transaction_log
+  RENAME stmt_date TO txid_time;
+
+COMMENT ON COLUMN pgmemento.transaction_log.txid_time IS 'Stores the result of transaction_timestamp() function';

--- a/src/CTL.sql
+++ b/src/CTL.sql
@@ -433,6 +433,6 @@ CREATE OR REPLACE FUNCTION pgmemento.version(
   OUT build_id TEXT
   ) RETURNS RECORD AS
 $$
-SELECT 'pgMemento 0.7'::text AS full_version, 0 AS major_version, 7 AS minor_version, '56'::text AS build_id;
+SELECT 'pgMemento 0.7'::text AS full_version, 0 AS major_version, 7 AS minor_version, '57'::text AS build_id;
 $$
 LANGUAGE sql;


### PR DESCRIPTION
The current version of the UPGRADE script tries to update entire log tables (`table_event_log` even twice). That's not so smart. Instead, creating copies of the logs tables would be much faster and won't take up more disk space than updating every row.

The replacement of log triggers is now done in the UPGRADE script, just in the moment, when the original `table_event_log` and `row_log` are dropped and their copies become part of the audit trail.