### PR TITLE
fix delete log functions and cover them with tests

### DIFF
--- a/src/CTL.sql
+++ b/src/CTL.sql
@@ -433,6 +433,6 @@ CREATE OR REPLACE FUNCTION pgmemento.version(
   OUT build_id TEXT
   ) RETURNS RECORD AS
 $$
-SELECT 'pgMemento 0.7'::text AS full_version, 0 AS major_version, 7 AS minor_version, '58'::text AS build_id;
+SELECT 'pgMemento 0.7'::text AS full_version, 0 AS major_version, 7 AS minor_version, '59'::text AS build_id;
 $$
 LANGUAGE sql;

--- a/src/LOG_UTIL.sql
+++ b/src/LOG_UTIL.sql
@@ -296,7 +296,7 @@ BEGIN
         log_id = table_log_id
         AND upper(txid_range) IS NOT NULL
       RETURNING
-        log_id;
+        id;
   ELSE
     RAISE NOTICE 'Either audit table is not found or the table still exists.';
   END IF;

--- a/src/LOG_UTIL.sql
+++ b/src/LOG_UTIL.sql
@@ -16,6 +16,8 @@
 -- ChangeLog:
 --
 -- Version | Date       | Description                                  | Author
+-- 0.7.6     2020-04-28   change new_data in row_log on update/delete    FKun
+--                        cover row_log when deleting events
 -- 0.7.5     2020-03-23   add audit_id_column to audit_table_check       FKun
 -- 0.7.4     2020-03-07   set SECURITY DEFINER where log tables are      FKun
 --                        touched
@@ -204,14 +206,27 @@ CREATE OR REPLACE FUNCTION pgmemento.delete_table_event_log(
   schemaname TEXT DEFAULT 'public'::text
   ) RETURNS SETOF INTEGER AS
 $$
-DELETE FROM
-  pgmemento.table_event_log
-WHERE
-  transaction_id = $1
-  AND table_name = $2
-  AND schema_name = $3
-RETURNING
-  id;
+WITH delete_table_event AS (
+  DELETE FROM
+    pgmemento.table_event_log
+  WHERE
+    transaction_id = $1
+    AND table_name = $2
+    AND schema_name = $3
+  RETURNING
+    id, event_key
+), delete_row_log_event AS (
+  DELETE FROM
+    pgmemento.row_log r
+  USING
+    delete_table_event dte
+  WHERE
+    dte.event_key = r.event_key
+)
+SELECT
+  id
+FROM
+  delete_table_event;
 $$
 LANGUAGE sql STRICT
 SECURITY DEFINER;
@@ -221,13 +236,26 @@ CREATE OR REPLACE FUNCTION pgmemento.delete_table_event_log(
   schemaname TEXT DEFAULT 'public'::text
   ) RETURNS SETOF INTEGER AS
 $$
-DELETE FROM
-  pgmemento.table_event_log
-WHERE
-  table_name = $1
-  AND schema_name = $2
-RETURNING
-  id;
+WITH delete_table_event AS (
+  DELETE FROM
+    pgmemento.table_event_log
+  WHERE
+    table_name = $1
+    AND schema_name = $2
+  RETURNING
+    id, event_key
+), delete_row_log_event AS (
+  DELETE FROM
+    pgmemento.row_log r
+  USING
+    delete_table_event dte
+  WHERE
+    dte.event_key = r.event_key
+)
+SELECT
+  id
+FROM
+  delete_table_event;
 $$
 LANGUAGE sql STRICT
 SECURITY DEFINER;
@@ -290,15 +318,68 @@ CREATE OR REPLACE FUNCTION pgmemento.delete_key(
   old_value anyelement
   ) RETURNS SETOF BIGINT AS
 $$
-UPDATE
-  pgmemento.row_log
-SET
-  old_data = old_data - $2
-WHERE
-  audit_id = $1
-  AND old_data @> jsonb_build_object($2, $3)
-RETURNING
-  id;
+WITH find_log AS (
+  SELECT
+    id AS row_log_id,
+    event_key AS log_event,
+    new_data AS new_log
+  FROM
+    pgmemento.row_log
+  WHERE
+    audit_id = $1
+    AND old_data @> jsonb_build_object($2, $3)
+),
+remove_key AS (
+  UPDATE
+    pgmemento.row_log r
+  SET
+    old_data = r.old_data - $2,
+    new_data = r.new_data - $2
+  FROM
+    find_log f
+  WHERE
+    r.id = f.row_log_id
+  RETURNING
+    r.id
+),
+remove_prev_new_key AS (
+  UPDATE
+    pgmemento.row_log r
+  SET
+    new_data = r.new_data - $2
+  FROM
+    find_log f
+  WHERE
+    r.audit_id = $1
+    AND r.event_key < f.log_event
+    AND r.new_data @> jsonb_build_object($2, $3)
+    AND f.new_log IS NULL
+  RETURNING
+    r.id
+),
+update_prev_new_key AS (
+  UPDATE
+    pgmemento.row_log r
+  SET
+    new_data = jsonb_set(new_data, ARRAY[$2], f.new_log -> $2, FALSE)
+  FROM
+    find_log f
+  WHERE
+    r.audit_id = $1
+    AND r.event_key < f.log_event
+    AND r.new_data @> jsonb_build_object($2, $3)
+    AND f.new_log IS NOT NULL
+  RETURNING
+    r.id
+)
+SELECT id FROM (
+  SELECT id FROM remove_key
+  UNION
+  SELECT id FROM remove_prev_new_key
+  UNION
+  SELECT id FROM update_prev_new_key
+) dlog
+ORDER BY id;
 $$
 LANGUAGE sql
 SECURITY DEFINER;
@@ -310,15 +391,33 @@ CREATE OR REPLACE FUNCTION pgmemento.update_key(
   new_value anyelement
   ) RETURNS SETOF BIGINT AS
 $$
-UPDATE
-  pgmemento.row_log
-SET
-  old_data = jsonb_set(old_data, $2, to_jsonb($4), FALSE)
-WHERE
-  audit_id = $1
-  AND old_data @> jsonb_build_object($2[1], $3)
-RETURNING
-  id;
+WITH update_old_key AS (
+  UPDATE
+    pgmemento.row_log
+  SET
+    old_data = jsonb_set(old_data, $2, to_jsonb($4), FALSE)
+  WHERE
+    audit_id = $1
+    AND old_data @> jsonb_build_object($2[1], $3)
+  RETURNING
+    id
+), update_new_key AS (
+  UPDATE
+    pgmemento.row_log
+  SET
+    new_data = jsonb_set(new_data, $2, to_jsonb($4), FALSE)
+  WHERE
+    audit_id = $1
+    AND new_data @> jsonb_build_object($2[1], $3)
+  RETURNING
+    id
+)
+SELECT id FROM (
+  SELECT id FROM update_old_key
+  UNION
+  SELECT id FROM update_new_key
+) ulog
+ORDER BY id;
 $$
 LANGUAGE sql
 SECURITY DEFINER;

--- a/test/SUITE.sql
+++ b/test/SUITE.sql
@@ -52,6 +52,9 @@ VALUES
 \i test/restore/TEST_RESTORE_RECORDSETS.sql;
 \i test/restore/TEST_RESTORE_TABLE_STATE.sql;
 
+-- test util functions
+\i test/log_util/TEST_DELETE_LOGS.sql
+
 -- test CTL functions and uninstalling
 \i test/setup/TEST_STOP_START.sql
 \i test/setup/TEST_UNINSTALL.sql

--- a/test/log_util/TEST_DELETE_LOGS.sql
+++ b/test/log_util/TEST_DELETE_LOGS.sql
@@ -1,0 +1,204 @@
+-- TEST_DELETE_LOGS.sql
+--
+-- Author:      Felix Kunde <felix-kunde@gmx.de>
+--
+--              This script is free software under the LGPL Version 3
+--              See the GNU Lesser General Public License at
+--              http://www.gnu.org/copyleft/lgpl.html
+--              for more details.
+-------------------------------------------------------------------------------
+-- About:
+-- Script that checks log tables when an DELETE event happens
+-------------------------------------------------------------------------------
+--
+-- ChangeLog:
+--
+-- Version | Date       | Description                                    | Author
+-- 0.1.0     2020-04-29   initial commit                                   FKun
+--
+
+-- get test number
+SELECT nextval('pgmemento.test_seq') AS n \gset
+
+\echo
+\echo 'TEST ':n': pgMemento delete from log tables'
+
+-- create new table for tests
+CREATE TABLE public.util_test AS
+SELECT 'update_me' AS a, 'delete_me' AS b;
+
+-- take baseline
+SELECT pgmemento.log_table_baseline('util_test', 'public', 'pgmemento_audit_id', TRUE);
+
+-- generate log entry for util_test table
+UPDATE public.util_test SET a = 'ok', b = 'delete_me_next'
+RETURNING pgmemento_audit_id \gset
+
+SELECT set_config('pgmemento.delete_logs_test_aid', :pgmemento_audit_id::text, FALSE);
+
+SELECT transaction_id, event_key
+  FROM pgmemento.table_event_log
+ WHERE table_name = 'util_test'
+   AND schema_name = 'public'
+   AND op_id = 4 \gset
+
+SELECT set_config('pgmemento.delete_logs_test_transaction', :transaction_id::text, FALSE);
+SELECT set_config('pgmemento.delete_logs_test_event', :'event_key', FALSE);
+
+\echo
+\echo 'TEST ':n'.1: Delete field in row_log'
+DO
+$$
+DECLARE
+  row_log_ids BIGINT[];
+  old_jsonb_log JSONB[];
+  new_jsonb_log JSONB[];
+BEGIN
+  SELECT
+    array_agg(r.id)
+  INTO
+    row_log_ids
+  FROM
+    pgmemento.delete_key(current_setting('pgmemento.delete_logs_test_aid')::bigint, 'b', 'delete_me'::text) AS r(id);
+
+  -- query row_log
+  SELECT
+    array_agg(r.old_data ORDER BY r.id),
+    array_agg(r.new_data ORDER BY r.id)
+  INTO
+    old_jsonb_log,
+    new_jsonb_log
+  FROM
+    pgmemento.row_log r
+  JOIN
+    unnest(row_log_ids) AS a(id)
+    ON r.id = a.id;
+
+  ASSERT old_jsonb_log[2] = ('{"a": "update_me"}')::jsonb, 'Error: Field not deleted from logs: %', old_jsonb_log[2];
+  ASSERT new_jsonb_log[1] ->> 'b' = 'delete_me_next', 'Error: Field not updated in logs. Expected "delete_me_next", got %', new_jsonb_log[1] ->> 'b';
+  ASSERT NOT(new_jsonb_log[2] ? 'b'), 'Error: Field not deleted from logs: %', new_jsonb_log[2];
+END;
+$$
+LANGUAGE plpgsql;
+
+\echo
+\echo 'TEST ':n'.2: Update field in row_log'
+DO
+$$
+DECLARE
+  row_log_ids BIGINT[];
+  old_jsonb_log JSONB[];
+  new_jsonb_log JSONB[];
+BEGIN
+  SELECT
+    array_agg(r.id)
+  INTO
+    row_log_ids
+  FROM
+    pgmemento.update_key(current_setting('pgmemento.delete_logs_test_aid')::bigint, '{a}', 'update_me'::text, 'update_me_next'::text) AS r(id);
+
+  -- query row_log
+  SELECT
+    array_agg(r.old_data ORDER BY r.id),
+    array_agg(r.new_data ORDER BY r.id)
+  INTO
+    old_jsonb_log,
+    new_jsonb_log
+  FROM
+    pgmemento.row_log r
+  JOIN
+    unnest(row_log_ids) AS a(id)
+    ON r.id = a.id;
+
+  ASSERT old_jsonb_log[2] = ('{"a": "update_me_next"}')::jsonb, 'Error: Field not updated in logs: %', old_jsonb_log[2];
+  ASSERT new_jsonb_log[1] ->> 'a' = 'update_me_next', 'Error: Field not updated in logs. Expected "update_me_next", got %', new_jsonb_log[1] ->> 'a';
+  ASSERT new_jsonb_log[2] = ('{"a": "ok"}')::jsonb, 'Error: Field not updated in logs: %', new_jsonb_log[2];
+END;
+$$
+LANGUAGE plpgsql;
+
+\echo
+\echo 'TEST ':n'.3: Delete logged event'
+DO
+$$
+DECLARE
+  event_ids INTEGER[];
+BEGIN
+  SELECT
+    array_agg(e_id)
+  INTO
+    event_ids
+  FROM (
+    SELECT
+      pgmemento.delete_table_event_log(transaction_id, 'util_test', 'public') AS e_id
+    FROM
+      pgmemento.table_event_log
+    WHERE
+      event_key = current_setting('pgmemento.delete_logs_test_event')
+  ) d;
+
+  ASSERT array_length(event_ids, 1) = 1, 'Error: Expected id array with 1 entry, but has %', array_length(event_ids, 1);
+  ASSERT (
+    SELECT NOT EXISTS (
+      SELECT
+        1
+      FROM
+        pgmemento.row_log
+      WHERE
+        event_key = current_setting('pgmemento.delete_logs_test_event')
+    )
+  ), 'Error: Logs of deleted table event still exist in row_log table!';
+END;
+$$
+LANGUAGE plpgsql;
+
+\echo
+\echo 'TEST ':n'.4: Delete all logs of audited table'
+DO
+$$
+DECLARE
+  audit_table_log_ids INTEGER[];
+BEGIN
+  -- first stop auditing for table to delete everything
+  PERFORM pgmemento.drop_table_audit('util_test', 'public', 'pgmemento_audit_id', TRUE, FALSE);
+
+  -- now call delete function
+  SELECT
+    array_agg(a_id)
+  INTO
+    audit_table_log_ids
+  FROM
+    pgmemento.delete_audit_table_log('util_test', 'public') AS a_id;
+
+  ASSERT array_length(audit_table_log_ids, 1) = 1, 'Error: Expected id array with 1 entry, but has %', array_length(audit_table_log_ids, 1);
+  ASSERT (
+    SELECT NOT EXISTS (
+      SELECT
+        1
+      FROM
+        pgmemento.table_event_log
+      WHERE
+        table_name = 'util_test'
+        AND schema_name = 'public'
+    )
+  ), 'Error: Logs for given table still exist in table_event_log table!';
+END;
+$$
+LANGUAGE plpgsql;
+
+\echo
+\echo 'TEST ':n'.5: Delete logged transaction'
+DO
+$$
+DECLARE
+  transaction_id INTEGER;
+BEGIN
+  SELECT
+    pgmemento.delete_txid_log(current_setting('pgmemento.delete_logs_test_transaction')::int)
+  INTO
+    transaction_id;
+
+  ASSERT transaction_id = current_setting('pgmemento.delete_logs_test_transaction')::int, 'Error: Expected transaction id %, got %', current_setting('pgmemento.delete_logs_test_transaction')::int, transaction_id;
+END;
+$$
+LANGUAGE plpgsql;


### PR DESCRIPTION
`delete_table_event_log` functions were still expecting a foreign key to `row_log` table for cascading deletes. Now they also clean up in `row_log`.

Log correction functions `delete_key` and `update_key` were only covering the `old_data` audit trail. But the new `new_data` column in `row_log` makes updating the log a bit trickier. E.g. if a key is removed from an update log, the new value must be shifted to the previous transaction. So far, only this direction is supported.