### PR TITLE
log session_user instead of current_user in security definer function

### DIFF
--- a/src/CTL.sql
+++ b/src/CTL.sql
@@ -436,6 +436,6 @@ CREATE OR REPLACE FUNCTION pgmemento.version(
   OUT build_id TEXT
   ) RETURNS RECORD AS
 $$
-SELECT 'pgMemento 0.7.0'::text AS full_version, 0 AS major_version, 7 AS minor_version, 0 AS revision, '60'::text AS build_id;
+SELECT 'pgMemento 0.7.0'::text AS full_version, 0 AS major_version, 7 AS minor_version, 0 AS revision, '63'::text AS build_id;
 $$
 LANGUAGE sql;

--- a/src/SCHEMA.sql
+++ b/src/SCHEMA.sql
@@ -88,7 +88,7 @@ COMMENT ON COLUMN pgmemento.transaction_log.id IS 'The Primary Key';
 COMMENT ON COLUMN pgmemento.transaction_log.txid IS 'The internal transaction ID by PostgreSQL (can cycle)';
 COMMENT ON COLUMN pgmemento.transaction_log.txid_time IS 'Stores the result of transaction_timestamp() function';
 COMMENT ON COLUMN pgmemento.transaction_log.process_id IS 'Stores the result of pg_backend_pid() function';
-COMMENT ON COLUMN pgmemento.transaction_log.user_name IS 'Stores the result of current_user function';
+COMMENT ON COLUMN pgmemento.transaction_log.user_name IS 'Stores the result of session_user function';
 COMMENT ON COLUMN pgmemento.transaction_log.client_name IS 'Stores the result of inet_client_addr() function';
 COMMENT ON COLUMN pgmemento.transaction_log.client_port IS 'Stores the result of inet_client_port() function';
 COMMENT ON COLUMN pgmemento.transaction_log.application_name IS 'Stores the output of current_setting(''application_name'')';

--- a/src/SETUP.sql
+++ b/src/SETUP.sql
@@ -949,7 +949,7 @@ BEGIN
   INSERT INTO pgmemento.transaction_log
     (txid, txid_time, process_id, user_name, client_name, client_port, application_name, session_info)
   VALUES
-    ($1, transaction_timestamp(), pg_backend_pid(), current_user, inet_client_addr(), inet_client_port(),
+    ($1, transaction_timestamp(), pg_backend_pid(), session_user, inet_client_addr(), inet_client_port(),
      current_setting('application_name'), session_info_obj
     )
   ON CONFLICT (txid_time, txid)


### PR DESCRIPTION
Calling `current_user` from a `SECURITY DEFINER` function returns it's owner, not an actual session user. So `postgres` value was always logged to `user_name` column in `transaction_log` table. This fixes it.