### PR TITLE
filter by command_tag in event triggers

### DIFF
--- a/src/DDL_LOG.sql
+++ b/src/DDL_LOG.sql
@@ -727,7 +727,7 @@ BEGIN
   FOR obj IN
     SELECT * FROM pg_event_trigger_ddl_commands()
   LOOP
-    IF obj.command_tag != 'ALTER TABLE' AND obj.object_type != 'table' THEN
+    IF obj.command_tag != 'ALTER TABLE' OR obj.object_type != 'table' THEN
       CONTINUE;
     END IF;
 
@@ -1071,7 +1071,7 @@ BEGIN
   FOR obj IN
     SELECT * FROM pg_event_trigger_ddl_commands()
   LOOP
-    IF obj.command_tag != 'CREATE TABLE' AND obj.object_type != 'table' THEN
+    IF obj.command_tag != 'CREATE TABLE' OR obj.object_type != 'table' THEN
       CONTINUE;
     END IF;
 

--- a/src/DDL_LOG.sql
+++ b/src/DDL_LOG.sql
@@ -727,10 +727,6 @@ BEGIN
   FOR obj IN
     SELECT * FROM pg_event_trigger_ddl_commands()
   LOOP
-    IF obj.command_tag != 'ALTER TABLE' OR obj.object_type != 'table' THEN
-      CONTINUE;
-    END IF;
-
     -- get table from trigger variable - remove quotes if exists
     tg_tablename := pgmemento.trim_outer_quotes(split_part(obj.object_identity, '.' ,2));
     tg_schemaname := pgmemento.trim_outer_quotes(split_part(obj.object_identity, '.' ,1));

--- a/src/DDL_LOG.sql
+++ b/src/DDL_LOG.sql
@@ -727,6 +727,10 @@ BEGIN
   FOR obj IN
     SELECT * FROM pg_event_trigger_ddl_commands()
   LOOP
+    IF obj.command_tag != 'ALTER TABLE' AND obj.object_type != 'table' THEN
+      CONTINUE;
+    END IF;
+
     -- get table from trigger variable - remove quotes if exists
     tg_tablename := pgmemento.trim_outer_quotes(split_part(obj.object_identity, '.' ,2));
     tg_schemaname := pgmemento.trim_outer_quotes(split_part(obj.object_identity, '.' ,1));
@@ -1067,44 +1071,46 @@ BEGIN
   FOR obj IN
     SELECT * FROM pg_event_trigger_ddl_commands()
   LOOP
-    IF obj.object_type = 'table' THEN
-      -- remove quotes if exists
-      tablename := pgmemento.trim_outer_quotes(split_part(obj.object_identity, '.' ,2));
-      schemaname := pgmemento.trim_outer_quotes(split_part(obj.object_identity, '.' ,1));
+    IF obj.command_tag != 'CREATE TABLE' AND obj.object_type != 'table' THEN
+      CONTINUE;
+    END IF;
 
-      -- check if auditing is active for schema
-      SELECT
-        default_audit_id_column,
-        default_log_old_data,
-        default_log_new_data
-      INTO
+    -- remove quotes if exists
+    tablename := pgmemento.trim_outer_quotes(split_part(obj.object_identity, '.' ,2));
+    schemaname := pgmemento.trim_outer_quotes(split_part(obj.object_identity, '.' ,1));
+
+    -- check if auditing is active for schema
+    SELECT
+      default_audit_id_column,
+      default_log_old_data,
+      default_log_new_data
+    INTO
+      current_default_column,
+      current_log_old_data,
+      current_log_new_data
+    FROM
+      pgmemento.audit_schema_log
+    WHERE
+      schema_name = schemaname
+      AND upper(txid_range) IS NULL;
+
+    IF current_default_column IS NOT NULL THEN
+      -- log as 'create table' event
+      PERFORM pgmemento.log_table_event(
+        tablename,
+        schemaname,
+        'CREATE TABLE'
+      );
+
+      -- start auditing for new table
+      PERFORM pgmemento.create_table_audit(
+        tablename,
+        schemaname,
         current_default_column,
         current_log_old_data,
-        current_log_new_data
-      FROM
-        pgmemento.audit_schema_log
-      WHERE
-        schema_name = schemaname
-        AND upper(txid_range) IS NULL;
-
-      IF current_default_column IS NOT NULL THEN
-        -- log as 'create table' event
-        PERFORM pgmemento.log_table_event(
-          tablename,
-          schemaname,
-          'CREATE TABLE'
-        );
-
-        -- start auditing for new table
-        PERFORM pgmemento.create_table_audit(
-          tablename,
-          schemaname,
-          current_default_column,
-          current_log_old_data,
-          current_log_new_data,
-          FALSE
-        );
-      END IF;
+        current_log_new_data,
+        FALSE
+      );
     END IF;
   END LOOP;
 END;

--- a/src/DDL_LOG.sql
+++ b/src/DDL_LOG.sql
@@ -1067,7 +1067,7 @@ BEGIN
   FOR obj IN
     SELECT * FROM pg_event_trigger_ddl_commands()
   LOOP
-    IF obj.command_tag != 'CREATE TABLE' OR obj.object_type != 'table' THEN
+    IF obj.command_tag NOT IN ('CREATE TABLE', 'CREATE TABLE AS', 'SELECT INTO') OR obj.object_type != 'table' THEN
       CONTINUE;
     END IF;
 


### PR DESCRIPTION
fixes #68 

The following statement triggers the `table_create_post_trigger`:
```create table test2 (id serial primary key, test_id integer references test (id));```

But within the event trigger `pg_event_trigger_ddl_commands()` returns more table object than expected:
```
obj 1: sequence, CREATE SEQUENCE
obj 2: table, CREATE TABLE -> creates auditing
obj 3: index, CREATE INDEX
obj 4: table, ALTER TABLE -> produces error
obj 5: sequence, ALTER SEQUENCE
```

The ALTER TABLE event, triggered by the foreign key, leads to a second unneccessary attempt to initialize auditing for that table.