### PR TITLE
Fix for postgres 14

### DIFF
--- a/.github/workflows/pgmemento-test-upgrade.yml
+++ b/.github/workflows/pgmemento-test-upgrade.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pg: [9.6, 10, 11, 12, 13]
+        pg: [9.6, 10, 11, 12, 13, 14]
     services:
       postgres:
         image: postgis/postgis:${{ matrix.pg }}-3.1

--- a/.github/workflows/pgmemento-tests.yml
+++ b/.github/workflows/pgmemento-tests.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pg: [9.6, 10, 11, 12, 13]
+        pg: [9.6, 10, 11, 12, 13, 14]
     services:
       postgres:
         image: postgis/postgis:${{ matrix.pg }}-3.1

--- a/UPGRADE_v07_to_v072.sql
+++ b/UPGRADE_v07_to_v072.sql
@@ -78,10 +78,10 @@ BEGIN
   END IF;
 
   -- remember audit_id_column when registering table in audit_table_log later
-  PERFORM set_config('pgmemento.' || $2 || '.' || $1 || '.audit_id.' || txid_current(), $3, TRUE);
+  PERFORM set_config('pgmemento.' || $2 || '.' || $1 || '.audit_id.t' || txid_current(), $3, TRUE);
 
   -- remember logging behavior when registering table in audit_table_log later
-  PERFORM set_config('pgmemento.' || $2 || '.' || $1 || '.log_data.' || txid_current(),
+  PERFORM set_config('pgmemento.' || $2 || '.' || $1 || '.log_data.t' || txid_current(),
     CASE WHEN log_old_data THEN 'old=true,' ELSE 'old=false,' END ||
     CASE WHEN log_new_data THEN 'new=true' ELSE 'new=false' END, TRUE);
 
@@ -143,9 +143,9 @@ BEGIN
   INTO transaction_log_id;
 
   IF transaction_log_id IS NOT NULL THEN
-    PERFORM set_config('pgmemento.' || $1, transaction_log_id::text, TRUE);
+    PERFORM set_config('pgmemento.t' || $1, transaction_log_id::text, TRUE);
   ELSE
-    transaction_log_id := current_setting('pgmemento.' || $1)::int;
+    transaction_log_id := current_setting('pgmemento.t' || $1)::int;
   END IF;
 
   RETURN transaction_log_id;
@@ -535,7 +535,7 @@ BEGIN
         FROM
           pgmemento.table_event_log
         WHERE
-          transaction_id = current_setting('pgmemento.' || txid_current())::int
+          transaction_id = current_setting('pgmemento.t' || txid_current())::int
           AND table_name = $5
           AND schema_name = $6
           AND op_id = 11  -- REINIT TABLE event
@@ -840,7 +840,7 @@ BEGIN
   WHEN $4 = 81 THEN
     -- first check if a preceding CREATE TABLE event already recreated the audit_id
     BEGIN
-      current_transaction := current_setting('pgmemento.' || txid_current())::int;
+      current_transaction := current_setting('pgmemento.t' || txid_current())::int;
 
       EXCEPTION
         WHEN undefined_object THEN

--- a/extension/tests/Dockerfile-10
+++ b/extension/tests/Dockerfile-10
@@ -1,2 +1,2 @@
 FROM postgres:10
-RUN apt-get update -y && apt-get install -y postgresql-10-postgis-3 cmake libpq-dev postgresql-server-dev-10 zip unzip python-pip
+RUN apt-get update -y && apt-get install -y postgresql-10-postgis-3 cmake libpq-dev postgresql-server-dev-10 zip unzip python3-pip

--- a/extension/tests/Dockerfile-11
+++ b/extension/tests/Dockerfile-11
@@ -1,2 +1,2 @@
 FROM postgres:11
-RUN apt-get update -y && apt-get install -y postgresql-11-postgis-3 cmake libpq-dev postgresql-server-dev-11 zip unzip python-pip
+RUN apt-get update -y && apt-get install -y postgresql-11-postgis-3 cmake libpq-dev postgresql-server-dev-11 zip unzip python3-pip

--- a/extension/tests/Dockerfile-12
+++ b/extension/tests/Dockerfile-12
@@ -1,2 +1,2 @@
 FROM postgres:12
-RUN apt-get update -y && apt-get install -y postgresql-12-postgis-3 cmake libpq-dev postgresql-server-dev-12 zip unzip python-pip
+RUN apt-get update -y && apt-get install -y postgresql-12-postgis-3 cmake libpq-dev postgresql-server-dev-12 zip unzip python3-pip

--- a/extension/tests/Dockerfile-13
+++ b/extension/tests/Dockerfile-13
@@ -1,2 +1,2 @@
 FROM postgres:13
-RUN apt-get update -y && apt-get install -y postgresql-13-postgis-3 cmake libpq-dev postgresql-server-dev-13 zip unzip python-pip
+RUN apt-get update -y && apt-get install -y postgresql-13-postgis-3 cmake libpq-dev postgresql-server-dev-13 zip unzip python3-pip

--- a/extension/tests/Dockerfile-14
+++ b/extension/tests/Dockerfile-14
@@ -1,0 +1,2 @@
+FROM postgres:14
+RUN apt-get update -y && apt-get install -y postgresql-14-postgis-3 cmake libpq-dev postgresql-server-dev-14 zip unzip python3-pip

--- a/extension/tests/Dockerfile-95
+++ b/extension/tests/Dockerfile-95
@@ -2,4 +2,4 @@ FROM postgres:9.5
 
 ENV PG_EXTENSION_DIR /usr/share/postgresql/9.5/extension/
 
-RUN apt-get update -y && apt-get install -y postgresql-9.5-postgis-3 cmake libpq-dev postgresql-server-dev-9.5 zip unzip python-pip
+RUN apt-get update -y && apt-get install -y postgresql-9.5-postgis-3 cmake libpq-dev postgresql-server-dev-9.5 zip unzip python3-pip

--- a/extension/tests/Dockerfile-96
+++ b/extension/tests/Dockerfile-96
@@ -1,2 +1,2 @@
 FROM postgres:9.6
-RUN apt-get update -y && apt-get install -y postgresql-9.6-postgis-3 cmake libpq-dev postgresql-server-dev-9.6 zip unzip python-pip
+RUN apt-get update -y && apt-get install -y postgresql-9.6-postgis-3 cmake libpq-dev postgresql-server-dev-9.6 zip unzip python3-pip

--- a/src/REVERT.sql
+++ b/src/REVERT.sql
@@ -122,7 +122,7 @@ BEGIN
         FROM
           pgmemento.table_event_log
         WHERE
-          transaction_id = current_setting('pgmemento.' || txid_current())::int
+          transaction_id = current_setting('pgmemento.t' || txid_current())::int
           AND table_name = $5
           AND schema_name = $6
           AND op_id = 11  -- REINIT TABLE event
@@ -427,7 +427,7 @@ BEGIN
   WHEN $4 = 81 THEN
     -- first check if a preceding CREATE TABLE event already recreated the audit_id
     BEGIN
-      current_transaction := current_setting('pgmemento.' || txid_current())::int;
+      current_transaction := current_setting('pgmemento.t' || txid_current())::int;
 
       EXCEPTION
         WHEN undefined_object THEN

--- a/src/SETUP.sql
+++ b/src/SETUP.sql
@@ -423,7 +423,7 @@ BEGIN
   UPDATE
     pgmemento.audit_table_log
   SET
-    txid_range = numrange(lower(txid_range), current_setting('pgmemento.' || txid_current())::numeric, '(]')
+    txid_range = numrange(lower(txid_range), current_setting('pgmemento.t' || txid_current())::numeric, '(]')
   WHERE
     table_name = $1
     AND schema_name = $2
@@ -437,7 +437,7 @@ BEGIN
     UPDATE
       pgmemento.audit_column_log
     SET
-      txid_range = numrange(lower(txid_range), current_setting('pgmemento.' || txid_current())::numeric, '(]')
+      txid_range = numrange(lower(txid_range), current_setting('pgmemento.t' || txid_current())::numeric, '(]')
     WHERE
       audit_table_id = tab_id
       AND upper(txid_range) IS NULL
@@ -486,7 +486,7 @@ BEGIN
       FROM
         pgmemento.table_event_log
       WHERE
-        transaction_id = current_setting('pgmemento.' || txid_current())::int
+        transaction_id = current_setting('pgmemento.t' || txid_current())::int
         AND table_name = $1
         AND schema_name = $2
         AND ((op_id = 1 AND table_operation = 'RECREATE TABLE')
@@ -517,10 +517,10 @@ BEGIN
   END IF;
 
   -- get audit_id_column name which was set in create_table_audit_id or in event trigger when renaming the table
-  audit_id_column_name := current_setting('pgmemento.' || $2 || '.' || $1 || '.audit_id.' || txid_current());
+  audit_id_column_name := current_setting('pgmemento.' || $2 || '.' || $1 || '.audit_id.t' || txid_current());
 
   -- get logging behavior which was set in create_table_audit_id or in event trigger when renaming the table
-  log_data_settings := current_setting('pgmemento.' || $2 || '.' || $1 || '.log_data.' || txid_current());
+  log_data_settings := current_setting('pgmemento.' || $2 || '.' || $1 || '.log_data.t' || txid_current());
 
   -- now register table and corresponding columns in audit tables
   INSERT INTO pgmemento.audit_table_log
@@ -529,7 +529,7 @@ BEGIN
     (table_log_id, pgmemento.get_table_oid($1, $2), $2, $1, audit_id_column_name,
      CASE WHEN split_part(log_data_settings, ',' ,1) = 'old=true' THEN TRUE ELSE FALSE END,
      CASE WHEN split_part(log_data_settings, ',' ,2) = 'new=true' THEN TRUE ELSE FALSE END,
-     numrange(current_setting('pgmemento.' || txid_current())::numeric, NULL, '(]'))
+     numrange(current_setting('pgmemento.t' || txid_current())::numeric, NULL, '(]'))
   RETURNING id INTO tab_id;
 
   -- insert columns of new audited table into 'audit_column_log'
@@ -548,7 +548,7 @@ BEGIN
         position('.' IN format_type(a.atttypid, a.atttypmod))+1,
         length(format_type(a.atttypid, a.atttypmod))
       ) AS data_type,
-      numrange(current_setting('pgmemento.' || txid_current())::numeric, NULL, '(]') AS txid_range
+      numrange(current_setting('pgmemento.t' || txid_current())::numeric, NULL, '(]') AS txid_range
     FROM
       pg_attribute a
     LEFT JOIN
@@ -961,9 +961,9 @@ BEGIN
   INTO transaction_log_id;
 
   IF transaction_log_id IS NOT NULL THEN
-    PERFORM set_config('pgmemento.' || $1, transaction_log_id::text, TRUE);
+    PERFORM set_config('pgmemento.t' || $1, transaction_log_id::text, TRUE);
   ELSE
-    transaction_log_id := current_setting('pgmemento.' || $1)::int;
+    transaction_log_id := current_setting('pgmemento.t' || $1)::int;
   END IF;
 
   RETURN transaction_log_id;
@@ -1045,7 +1045,7 @@ BEGIN
   FROM
     pgmemento.table_event_log
   WHERE
-    transaction_id = current_setting('pgmemento.' || txid_current())::int
+    transaction_id = current_setting('pgmemento.t' || txid_current())::int
     AND table_name = TG_TABLE_NAME
     AND schema_name = TG_TABLE_SCHEMA
     AND op_id = 8;
@@ -1311,10 +1311,10 @@ BEGIN
   END IF;
 
   -- remember audit_id_column when registering table in audit_table_log later
-  PERFORM set_config('pgmemento.' || $2 || '.' || $1 || '.audit_id.' || txid_current(), $3, TRUE);
+  PERFORM set_config('pgmemento.' || $2 || '.' || $1 || '.audit_id.t' || txid_current(), $3, TRUE);
 
   -- remember logging behavior when registering table in audit_table_log later
-  PERFORM set_config('pgmemento.' || $2 || '.' || $1 || '.log_data.' || txid_current(),
+  PERFORM set_config('pgmemento.' || $2 || '.' || $1 || '.log_data.t' || txid_current(),
     CASE WHEN log_old_data THEN 'old=true,' ELSE 'old=false,' END ||
     CASE WHEN log_new_data THEN 'new=true' ELSE 'new=false' END, TRUE);
 

--- a/test/ddl_log/TEST_ADD_COLUMN.sql
+++ b/test/ddl_log/TEST_ADD_COLUMN.sql
@@ -40,7 +40,7 @@ BEGIN
   ALTER TABLE public.tests ADD COLUMN test_json_column JSON DEFAULT '{"test": "value"}'::json, ADD COLUMN test_tsrange_column tsrange;
 
   -- save transaction_id for next tests
-  test_transaction := current_setting('pgmemento.' || test_txid)::int;
+  test_transaction := current_setting('pgmemento.t' || test_txid)::int;
   PERFORM set_config('pgmemento.add_column_test', test_transaction::text, FALSE);
 
   -- query for logged transaction

--- a/test/ddl_log/TEST_ALTER_COLUMN.sql
+++ b/test/ddl_log/TEST_ALTER_COLUMN.sql
@@ -56,7 +56,7 @@ BEGIN
   ALTER TABLE public.tests ALTER test_tsrange_column TYPE tstzrange USING tstzrange(lower(test_tsrange_column), upper(test_tsrange_column), '(]');
 
   -- save transaction_id for next tests
-  test_transaction := current_setting('pgmemento.' || test_txid)::int;
+  test_transaction := current_setting('pgmemento.t' || test_txid)::int;
   PERFORM set_config('pgmemento.alter_column_test', test_transaction::text, FALSE);
 
   SELECT
@@ -151,7 +151,7 @@ BEGIN
   ALTER TABLE public.tests RENAME COLUMN test_tsrange_column TO test_tstzrange_column;
 
   -- save transaction_id for next tests
-  test_transaction := current_setting('pgmemento.' || test_txid)::int;
+  test_transaction := current_setting('pgmemento.t' || test_txid)::int;
   PERFORM set_config('pgmemento.rename_column_test', test_transaction::text, FALSE);
 
   -- query for logged transaction

--- a/test/ddl_log/TEST_ALTER_TABLE.sql
+++ b/test/ddl_log/TEST_ALTER_TABLE.sql
@@ -37,7 +37,7 @@ BEGIN
   ALTER TABLE public.test RENAME TO tests;
 
   -- save transaction_id for next tests
-  test_transaction := current_setting('pgmemento.' || test_txid)::int;
+  test_transaction := current_setting('pgmemento.t' || test_txid)::int;
   PERFORM set_config('pgmemento.rename_table_test', test_transaction::text, FALSE);
 
   -- query for logged transaction

--- a/test/ddl_log/TEST_CREATE_TABLE.sql
+++ b/test/ddl_log/TEST_CREATE_TABLE.sql
@@ -43,7 +43,7 @@ BEGIN
   );
 
   -- save transaction_id for next tests
-  test_transaction := current_setting('pgmemento.' || test_txid)::int;
+  test_transaction := current_setting('pgmemento.t' || test_txid)::int;
   PERFORM set_config('pgmemento.create_table_test', test_transaction::text, FALSE);
 
   -- query for logged transaction

--- a/test/ddl_log/TEST_DROP_COLUMN.sql
+++ b/test/ddl_log/TEST_DROP_COLUMN.sql
@@ -37,7 +37,7 @@ BEGIN
   ALTER TABLE public.tests DROP test_tstzrange_column, DROP COLUMN test_column;
 
   -- save transaction_id for next tests
-  test_transaction := current_setting('pgmemento.' || test_txid)::int;
+  test_transaction := current_setting('pgmemento.t' || test_txid)::int;
   PERFORM set_config('pgmemento.drop_column_test', test_transaction::text, FALSE);
 
   -- query for logged transaction
@@ -60,7 +60,7 @@ BEGIN
   FROM
     pgmemento.table_event_log
   WHERE
-    transaction_id = current_setting('pgmemento.' || test_txid)::int
+    transaction_id = current_setting('pgmemento.t' || test_txid)::int
     AND op_id = pgmemento.get_operation_id('DROP COLUMN');
 
   ASSERT test_event IS NOT NULL, 'Error: Did not find test entry in table_event_log table!';

--- a/test/ddl_log/TEST_DROP_TABLE.sql
+++ b/test/ddl_log/TEST_DROP_TABLE.sql
@@ -40,7 +40,7 @@ BEGIN
   DROP TABLE public.tests;
 
   -- save transaction_id for next tests
-  test_transaction := current_setting('pgmemento.' || test_txid)::int;
+  test_transaction := current_setting('pgmemento.t' || test_txid)::int;
   PERFORM set_config('pgmemento.drop_table_test', test_transaction::text, FALSE);
 
   -- query for logged transaction
@@ -63,7 +63,7 @@ BEGIN
   FROM
     pgmemento.table_event_log
   WHERE
-    transaction_id = current_setting('pgmemento.' || test_txid)::int
+    transaction_id = current_setting('pgmemento.t' || test_txid)::int
     AND (op_id = pgmemento.get_operation_id('TRUNCATE')
      OR op_id = pgmemento.get_operation_id('DROP TABLE'));
 

--- a/test/dml_log/TEST_DELETE.sql
+++ b/test/dml_log/TEST_DELETE.sql
@@ -65,7 +65,7 @@ BEGIN
   FROM
     pgmemento.table_event_log
   WHERE
-    transaction_id = current_setting('pgmemento.' || test_txid)::int
+    transaction_id = current_setting('pgmemento.t' || test_txid)::int
     AND op_id = delete_op_id;
 
   ASSERT test_event IS NOT NULL, 'Error: Did not find test entry in table_event_log table!';

--- a/test/dml_log/TEST_INSERT.sql
+++ b/test/dml_log/TEST_INSERT.sql
@@ -66,7 +66,7 @@ BEGIN
   FROM
     pgmemento.table_event_log
   WHERE
-    transaction_id = current_setting('pgmemento.' || test_txid)::int
+    transaction_id = current_setting('pgmemento.t' || test_txid)::int
     AND op_id = 3;
 
   ASSERT test_event IS NOT NULL, 'Error: Did not find test entry in table_event_log table!';
@@ -137,7 +137,7 @@ BEGIN
   FROM
     pgmemento.table_event_log
   WHERE
-    transaction_id = current_setting('pgmemento.' || test_txid)::int
+    transaction_id = current_setting('pgmemento.t' || test_txid)::int
     AND op_id = insert_op_id;
 
   ASSERT test_event IS NOT NULL, 'Error: Did not find test entry in table_event_log table!';
@@ -216,7 +216,7 @@ BEGIN
   FROM
     pgmemento.table_event_log
   WHERE
-    transaction_id = current_setting('pgmemento.' || test_txid)::int
+    transaction_id = current_setting('pgmemento.t' || test_txid)::int
     AND (op_id = pgmemento.get_operation_id('INSERT') OR op_id = pgmemento.get_operation_id('UPDATE'));
 
   ASSERT array_length(event_keys, 1) = 2, 'Error: Did not find entries in table_event_log table!';

--- a/test/dml_log/TEST_TRUNCATE.sql
+++ b/test/dml_log/TEST_TRUNCATE.sql
@@ -73,7 +73,7 @@ BEGIN
   FROM
     pgmemento.table_event_log
   WHERE
-    transaction_id = current_setting('pgmemento.' || test_txid)::int
+    transaction_id = current_setting('pgmemento.t' || test_txid)::int
     AND op_id = pgmemento.get_operation_id('TRUNCATE');
 
   ASSERT test_event IS NOT NULL, 'Error: Did not find test entry in table_event_log table!';

--- a/test/dml_log/TEST_UPDATE.sql
+++ b/test/dml_log/TEST_UPDATE.sql
@@ -61,7 +61,7 @@ BEGIN
   FROM
     pgmemento.table_event_log
   WHERE
-    transaction_id = current_setting('pgmemento.' || test_txid)::int
+    transaction_id = current_setting('pgmemento.t' || test_txid)::int
     AND op_id = update_op_id;
 
   ASSERT test_event IS NOT NULL, 'Error: Did not find test entry in table_event_log table!';
@@ -120,7 +120,7 @@ BEGIN
   FROM
     pgmemento.table_event_log
   WHERE
-    transaction_id = current_setting('pgmemento.' || test_txid)::int
+    transaction_id = current_setting('pgmemento.t' || test_txid)::int
     AND op_id = update_op_id;
 
   ASSERT test_event IS NOT NULL, 'Error: Did not find test entry in table_event_log table!';

--- a/test/setup/TEST_INIT.sql
+++ b/test/setup/TEST_INIT.sql
@@ -82,7 +82,7 @@ BEGIN
       FROM
         pgmemento.transaction_log
       WHERE
-        id = current_setting('pgmemento.' || txid_current())::numeric
+        id = current_setting('pgmemento.t' || txid_current())::numeric
         AND session_info ? 'pgmemento_init'
     )
   ), 'Error: Could not find entry in transaction_log for stopping audit trail in schema %!', tab_schema;

--- a/test/setup/TEST_STOP_START.sql
+++ b/test/setup/TEST_STOP_START.sql
@@ -43,7 +43,7 @@ BEGIN
       FROM
         pgmemento.transaction_log
       WHERE
-        id = current_setting('pgmemento.' || txid_current())::numeric
+        id = current_setting('pgmemento.t' || txid_current())::numeric
         AND session_info ? 'pgmemento_stop'
     )
   ), 'Error: Could not find entry in transaction_log for stopping audit trail in schema %!', tab_schema;
@@ -128,7 +128,7 @@ BEGIN
       FROM
         pgmemento.transaction_log
       WHERE
-        id = current_setting('pgmemento.' || txid_current())::numeric
+        id = current_setting('pgmemento.t' || txid_current())::numeric
         AND session_info ? 'pgmemento_start'
     )
   ), 'Error: Could not find entry in transaction_log for stopping audit trail in schema %!', tab_schema;
@@ -142,7 +142,7 @@ BEGIN
         pgmemento.audit_schema_log
       WHERE
         schema_name = tab_schema
-        AND lower(txid_range) = current_setting('pgmemento.' || txid_current())::numeric
+        AND lower(txid_range) = current_setting('pgmemento.t' || txid_current())::numeric
     )
   ), 'Error: Did not find entry for % schema in audit_schema_log!', tab_schema;
 END;

--- a/test/setup/TEST_UNINSTALL.sql
+++ b/test/setup/TEST_UNINSTALL.sql
@@ -44,7 +44,7 @@ BEGIN
       FROM
         pgmemento.transaction_log
       WHERE
-        id = current_setting('pgmemento.' || txid_current())::numeric
+        id = current_setting('pgmemento.t' || txid_current())::numeric
         AND session_info ? 'pgmemento_drop'
     )
   ), 'Error: Could not find entry in transaction_log for stopping audit trail in schema %!', tab_schema;
@@ -73,7 +73,7 @@ BEGIN
         pgmemento.audit_schema_log
       WHERE
         schema_name = tab_schema
-        AND upper(txid_range) = current_setting('pgmemento.' || txid_current())::numeric
+        AND upper(txid_range) = current_setting('pgmemento.t' || txid_current())::numeric
     )
   ), 'Error: Did not find entry for % schema in audit_schema_log!', tab_schema;
 END;


### PR DESCRIPTION
Postgres 14 tightened the requirements for custom settings. Specifically each part, separated by '.' has to start with a letter. pgMemento uses `pgmemento.123` a lot, where 123 is the transaction id, but that's not allowed anymore in Postgres 14.

More info:
https://github.com/postgres/postgres/commit/3db826bd55cd1df0dd8c3d811f8e5b936d7ba1e4
https://github.com/postgres/postgres/commit/2955c2be79b35fa369c83fa3b5f44661cb88afa9

This PR fixes this by just changing it to `pgmemento.t123`.

If I understand correctly, these custom settings are only temporary and reset after a transaction, so this change *should* be fine for existing installations.

Also added a dockerfile for Postgres 14 and updated the other dockerfiles because I always got an error when it tried to install `python-pip`.